### PR TITLE
Check Process::RLIMIT_RTTIME before use it.

### DIFF
--- a/core/process/getrlimit_spec.rb
+++ b/core/process/getrlimit_spec.rb
@@ -88,7 +88,7 @@ platform_is_not :windows do
 
         it "coerces :RTTIME into RLIMIT_RTTIME" do
           Process.getrlimit(:RTTIME).should == Process.getrlimit(Process::RLIMIT_RTTIME)
-        end
+        end if defined?(Process::RLIMIT_RTTIME)
 
         it "coerces :SIGPENDING into RLIMIT_SIGPENDING" do
           Process.getrlimit(:SIGPENDING).should == Process.getrlimit(Process::RLIMIT_SIGPENDING)
@@ -167,7 +167,7 @@ platform_is_not :windows do
 
         it "coerces 'RTTIME' into RLIMIT_RTTIME" do
           Process.getrlimit("RTTIME").should == Process.getrlimit(Process::RLIMIT_RTTIME)
-        end
+        end if defined?(Process::RLIMIT_RTTIME)
 
         it "coerces 'SIGPENDING' into RLIMIT_SIGPENDING" do
           Process.getrlimit("SIGPENDING").should == Process.getrlimit(Process::RLIMIT_SIGPENDING)

--- a/core/process/setrlimit_spec.rb
+++ b/core/process/setrlimit_spec.rb
@@ -100,7 +100,7 @@ platform_is_not :windows do
 
         it "coerces :RTTIME into RLIMIT_RTTIME" do
           Process.setrlimit(:RTTIME, *Process.getrlimit(Process::RLIMIT_RTTIME)).should be_nil
-        end
+        end if defined?(Process::RLIMIT_RTTIME)
 
         it "coerces :SIGPENDING into RLIMIT_SIGPENDING" do
           Process.setrlimit(:SIGPENDING, *Process.getrlimit(Process::RLIMIT_SIGPENDING)).should be_nil
@@ -178,7 +178,7 @@ platform_is_not :windows do
 
         it "coerces 'RTTIME' into RLIMIT_RTTIME" do
           Process.setrlimit("RTTIME", *Process.getrlimit(Process::RLIMIT_RTTIME)).should be_nil
-        end
+        end if defined?(Process::RLIMIT_RTTIME)
 
         it "coerces 'SIGPENDING' into RLIMIT_SIGPENDING" do
           Process.setrlimit("SIGPENDING", *Process.getrlimit(Process::RLIMIT_SIGPENDING)).should be_nil


### PR DESCRIPTION
Some old systems does not support RLIMIT_RTTIME.