### PR TITLE
Support LANG != C environment

### DIFF
--- a/core/io/popen_spec.rb
+++ b/core/io/popen_spec.rb
@@ -151,13 +151,13 @@ describe "IO.popen" do
       end
 
       it "accepts a single String command with a trailing Hash of Process.exec options" do
-        IO.popen({"FOO" => "nonexistent"}, "ls $FOO", :err => [:child, :out]) do |io|
+        IO.popen({"LANG" => "C", "FOO" => "nonexistent"}, "ls $FOO", :err => [:child, :out]) do |io|
           io.read.should =~ /No such file or directory/
         end
       end
 
       it "accepts a single String command with a trailing Hash of Process.exec options, and an IO mode" do
-        IO.popen({"FOO" => "nonexistent"}, "ls $FOO", "r", :err => [:child, :out]) do |io|
+        IO.popen({"LANG" => "C", "FOO" => "nonexistent"}, "ls $FOO", "r", :err => [:child, :out]) do |io|
           io.read.should =~ /No such file or directory/
         end
       end


### PR DESCRIPTION
For example, on environment LANG=ja_JP.UTF-8, then,

```
1)
IO.popen with a leading ENV Hash accepts a single String command with a trailing Hash of Process.exec options FAILED
Expected "ls: cannot access nonexistent: そのようなファイルやディレクトリはあり ません\n"
to match /No such file or directory/

/mnt/sdb1/ruby/trunk/spec/rubyspec/core/io/popen_spec.rb:155:in `block (5 levels) in <top (required)>'
/mnt/sdb1/ruby/trunk/spec/rubyspec/core/io/popen_spec.rb:154:in `popen'
/mnt/sdb1/ruby/trunk/spec/rubyspec/core/io/popen_spec.rb:154:in `block (4 levels) in <top (required)>'
/mnt/sdb1/ruby/trunk/spec/rubyspec/core/io/popen_spec.rb:4:in `<top (required)>'
```
