### PR TITLE
Add missing StringIO#close spec for Ruby >= 2.3.

### DIFF
--- a/library/stringio/close_spec.rb
+++ b/library/stringio/close_spec.rb
@@ -22,4 +22,11 @@ describe "StringIO#close" do
       lambda { @io.close }.should raise_error(IOError)
     end
   end
+
+  ruby_version_is "2.3" do
+    it "does not raise anything when self was already closed" do
+      @io.close
+      @io.close
+    end
+  end
 end


### PR DESCRIPTION
This notably fails on trunk, so it should be fixed on trunk first before merging.