### PR TITLE
Added specification for SizedQueue

### DIFF
--- a/library/queue/append_spec.rb
+++ b/library/queue/append_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/enque', __FILE__)
-
-describe "Queue#<<" do
-  it_behaves_like :queue_enq, :<<
-end

--- a/library/queue/deq_spec.rb
+++ b/library/queue/deq_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/deque', __FILE__)
-
-describe "Queue#deq" do
-  it_behaves_like :queue_deq, :deq
-end

--- a/library/queue/enq_spec.rb
+++ b/library/queue/enq_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/enque', __FILE__)
-
-describe "Queue#enq" do
-  it_behaves_like :queue_enq, :enq
-end

--- a/library/queue/length_spec.rb
+++ b/library/queue/length_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/length', __FILE__)
-
-describe "Queue#length" do
-  it_behaves_like :queue_length, :length
-end

--- a/library/queue/pop_spec.rb
+++ b/library/queue/pop_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/deque', __FILE__)
-
-describe "Queue#pop" do
-  it_behaves_like :queue_deq, :pop
-end

--- a/library/queue/push_spec.rb
+++ b/library/queue/push_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/enque', __FILE__)
-
-describe "Queue#push" do
-  it_behaves_like :queue_enq, :push
-end

--- a/library/queue/shift_spec.rb
+++ b/library/queue/shift_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/deque', __FILE__)
-
-describe "Queue#shift" do
-  it_behaves_like :queue_deq, :shift
-end

--- a/library/queue/size_spec.rb
+++ b/library/queue/size_spec.rb
@@ -1,7 +1,0 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-require File.expand_path('../shared/length', __FILE__)
-
-describe "Queue#size" do
-  it_behaves_like :queue_length, :size
-end

--- a/library/thread/queue/append_spec.rb
+++ b/library/thread/queue/append_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/enque', __FILE__)
+
+describe "Thread::Queue#<<" do
+  it_behaves_like :queue_enq, :<<, Queue.new
+end

--- a/library/thread/queue/clear_spec.rb
+++ b/library/thread/queue/clear_spec.rb
@@ -1,0 +1,9 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/clear', __FILE__)
+
+describe "Thread::Queue#clear" do
+  it_behaves_like :queue_clear, :clear, Queue.new
+
+  # TODO: test for atomicity of Queue#clear
+end

--- a/library/thread/queue/deq_spec.rb
+++ b/library/thread/queue/deq_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/deque', __FILE__)
+
+describe "Thread::Queue#deq" do
+  it_behaves_like :queue_deq, :deq, Queue.new
+end

--- a/library/thread/queue/empty_spec.rb
+++ b/library/thread/queue/empty_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/empty', __FILE__)
+
+describe "Thread::Queue#empty?" do
+  it_behaves_like :queue_empty?, :empty?, Queue.new
+end

--- a/library/thread/queue/enq_spec.rb
+++ b/library/thread/queue/enq_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/enque', __FILE__)
+
+describe "Thread::Queue#enq" do
+  it_behaves_like :queue_enq, :enq, Queue.new
+end

--- a/library/thread/queue/length_spec.rb
+++ b/library/thread/queue/length_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/length', __FILE__)
+
+describe "Thread::Queue#length" do
+  it_behaves_like :queue_length, :length, Queue.new
+end

--- a/library/thread/queue/num_waiting_spec.rb
+++ b/library/thread/queue/num_waiting_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/num_waiting', __FILE__)
+
+describe "Thread::Queue#num_waiting" do
+  it_behaves_like :queue_num_waiting, :num_waiting, Queue.new
+end

--- a/library/thread/queue/pop_spec.rb
+++ b/library/thread/queue/pop_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/deque', __FILE__)
+
+describe "Thread::Queue#pop" do
+  it_behaves_like :queue_deq, :pop, Queue.new
+end

--- a/library/thread/queue/push_spec.rb
+++ b/library/thread/queue/push_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/enque', __FILE__)
+
+describe "Thread::Queue#push" do
+  it_behaves_like :queue_enq, :push, Queue.new
+end

--- a/library/thread/queue/shift_spec.rb
+++ b/library/thread/queue/shift_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/deque', __FILE__)
+
+describe "Thread::Queue#shift" do
+  it_behaves_like :queue_deq, :shift, Queue.new
+end

--- a/library/thread/queue/size_spec.rb
+++ b/library/thread/queue/size_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/length', __FILE__)
+
+describe "Thread::Queue#size" do
+  it_behaves_like :queue_length, :size, Queue.new
+end

--- a/library/thread/shared/queue/clear.rb
+++ b/library/thread/shared/queue/clear.rb
@@ -1,15 +1,10 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-
-describe "Queue#clear" do
+describe :queue_clear, :shared => true do
   it "removes all objects from the queue" do
-    queue = Queue.new
+    queue = @object
     queue << Object.new
     queue << 1
     queue.empty?.should be_false
     queue.clear
     queue.empty?.should be_true
   end
-
-  # TODO: test for atomicity of Queue#clear
 end

--- a/library/thread/shared/queue/deque.rb
+++ b/library/thread/shared/queue/deque.rb
@@ -1,6 +1,6 @@
 describe :queue_deq, :shared => true do
   it "removes an item from the Queue" do
-    q = Queue.new
+    q = @object
     q << Object.new
     q.size.should == 1
     q.send(@method)
@@ -8,7 +8,7 @@ describe :queue_deq, :shared => true do
   end
 
   it "returns items in the order they were added" do
-    q = Queue.new
+    q = @object
     q << 1
     q << 2
     q.send(@method).should == 1
@@ -16,7 +16,7 @@ describe :queue_deq, :shared => true do
   end
 
   it "blocks the thread until there are items in the queue" do
-    q = Queue.new
+    q = @object
     v = 0
 
     th = Thread.new do
@@ -31,7 +31,7 @@ describe :queue_deq, :shared => true do
   end
 
   it "raises a ThreadError if Queue is empty" do
-    q = Queue.new
+    q = @object
     lambda { q.send(@method,true) }.should raise_error(ThreadError)
   end
 end

--- a/library/thread/shared/queue/empty.rb
+++ b/library/thread/shared/queue/empty.rb
@@ -1,14 +1,11 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-
-describe "Queue#empty?" do
+describe :queue_empty?, :shared => true do
   it "returns true on an empty Queue" do
-    queue = Queue.new
+    queue = @object
     queue.empty?.should be_true
   end
 
   it "returns false when Queue is not empty" do
-    queue = Queue.new
+    queue = @object
     queue << Object.new
     queue.empty?.should be_false
   end

--- a/library/thread/shared/queue/enque.rb
+++ b/library/thread/shared/queue/enque.rb
@@ -1,6 +1,6 @@
 describe :queue_enq, :shared => true do
   it "adds an element to the Queue" do
-    q = Queue.new
+    q = @object
     q.size.should == 0
     q.send(@method, Object.new)
     q.size.should == 1

--- a/library/thread/shared/queue/length.rb
+++ b/library/thread/shared/queue/length.rb
@@ -1,6 +1,6 @@
 describe :queue_length, :shared => true do
   it "returns the number of elements" do
-    q = Queue.new
+    q = @object
     q.send(@method).should == 0
     q << Object.new
     q << Object.new

--- a/library/thread/shared/queue/num_waiting.rb
+++ b/library/thread/shared/queue/num_waiting.rb
@@ -1,9 +1,6 @@
-require File.expand_path('../../../spec_helper', __FILE__)
-require 'thread'
-
-describe "Queue#num_waiting" do
-  it "reports the number of threads waiting on the Queue" do
-    q = Queue.new
+describe :queue_num_waiting, :shared => true do
+  it "reports the number of threads waiting on the queue" do
+    q = @object
     threads = []
 
     5.times do |i|

--- a/library/thread/sizedqueue/append_spec.rb
+++ b/library/thread/sizedqueue/append_spec.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/enque', __FILE__)
+require File.expand_path('../shared/enque', __FILE__)
+
+describe "Thread::SizedQueue#<<" do
+  it_behaves_like :queue_enq, :<<, SizedQueue.new(10)
+end
+
+describe "Thread::SizedQueue#<<" do
+  it_behaves_like :sizedqueue_enq, :<<, SizedQueue
+end

--- a/library/thread/sizedqueue/clear_spec.rb
+++ b/library/thread/sizedqueue/clear_spec.rb
@@ -1,0 +1,9 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/clear', __FILE__)
+
+describe "Thread::SizedQueue#clear" do
+  it_behaves_like :queue_clear, :clear, SizedQueue.new(10)
+
+  # TODO: test for atomicity of Queue#clear
+end

--- a/library/thread/sizedqueue/deq_spec.rb
+++ b/library/thread/sizedqueue/deq_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/deque', __FILE__)
+
+describe "Thread::SizedQueue#deq" do
+  it_behaves_like :queue_deq, :deq, SizedQueue.new(10)
+end

--- a/library/thread/sizedqueue/empty_spec.rb
+++ b/library/thread/sizedqueue/empty_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/empty', __FILE__)
+
+describe "Thread::SizedQueue#empty?" do
+  it_behaves_like :queue_empty?, :empty?, SizedQueue.new(10)
+end

--- a/library/thread/sizedqueue/enq_spec.rb
+++ b/library/thread/sizedqueue/enq_spec.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/enque', __FILE__)
+require File.expand_path('../shared/enque', __FILE__)
+
+describe "Thread::SizedQueue#enq" do
+  it_behaves_like :queue_enq, :enq, SizedQueue.new(10)
+end
+
+describe "Thread::SizedQueue#enq" do
+  it_behaves_like :sizedqueue_enq, :enq, SizedQueue
+end

--- a/library/thread/sizedqueue/length_spec.rb
+++ b/library/thread/sizedqueue/length_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/length', __FILE__)
+
+describe "Thread::SizedQueue#length" do
+  it_behaves_like :queue_length, :length, SizedQueue.new(10)
+end

--- a/library/thread/sizedqueue/max_spec.rb
+++ b/library/thread/sizedqueue/max_spec.rb
@@ -1,0 +1,53 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+
+describe "Thread::SizedQueue#max" do
+  before :each do
+    @sized_queue = SizedQueue.new(5)
+  end
+
+  it "returns the size of the queue" do
+    @sized_queue.max.should == 5
+  end
+end
+
+describe "Thread::SizedQueue#max=" do
+  before :each do
+    @sized_queue = SizedQueue.new(5)
+  end
+
+  it "sets the size of the queue" do
+    @sized_queue.max.should == 5
+    @sized_queue.max = 10
+    @sized_queue.max.should == 10
+  end
+
+  ruby_version_is ""..."2.1" do
+    it "raises a NoMethodError when a value without #>" do
+      lambda { @sized_queue.max = Object.new }.should raise_error(NoMethodError)
+    end
+
+    it "raises an ArgumentError for values not comparable to a number" do
+      lambda { @sized_queue.max = "foo" }.should raise_error(ArgumentError)
+    end
+  end
+
+  ruby_version_is "2.1" do
+    it "raises a TypeError when given a non-numeric value" do
+      lambda { @sized_queue.max = "foo" }.should raise_error(TypeError)
+      lambda { @sized_queue.max = Object.new }.should raise_error(TypeError)
+    end
+  end
+
+  it "raises an argument error when set to zero" do
+    @sized_queue.max.should == 5
+    lambda { @sized_queue.max = 0 }.should raise_error(ArgumentError)
+    @sized_queue.max.should == 5
+  end
+
+  it "raises an argument error when set to a negative number" do
+    @sized_queue.max.should == 5
+    lambda { @sized_queue.max = -1 }.should raise_error(ArgumentError)
+    @sized_queue.max.should == 5
+  end
+end

--- a/library/thread/sizedqueue/new_spec.rb
+++ b/library/thread/sizedqueue/new_spec.rb
@@ -1,0 +1,37 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+
+describe "Thread::SizedQueue#new" do
+  it "returns a new SizedQueue" do
+    SizedQueue.new(1).should be_kind_of(SizedQueue)
+  end
+
+  ruby_version_is ""..."2.1" do
+    it "raises a NoMethodError when an argument without #> is given" do
+      lambda { SizedQueue.new(Object.new) }.should raise_error(NoMethodError)
+    end
+
+    it "raises an ArgumentError for arguments not comparable to a number" do
+      lambda { SizedQueue.new("foo") }.should raise_error(ArgumentError)
+    end
+  end
+
+  ruby_version_is "2.1" do
+    it "raises a TypeError when the given argument is not Numeric" do
+      lambda { SizedQueue.new("foo") }.should raise_error(TypeError)
+      lambda { SizedQueue.new(Object.new) }.should raise_error(TypeError)
+    end
+  end
+
+  it "raises an argument error when no argument is given" do
+    lambda { SizedQueue.new }.should raise_error(ArgumentError)
+  end
+
+  it "raises an argument error when the given argument is zero" do
+    lambda { SizedQueue.new(0) }.should raise_error(ArgumentError)
+  end
+
+  it "raises an argument error when the given argument is negative" do
+    lambda { SizedQueue.new(-1) }.should raise_error(ArgumentError)
+  end
+end

--- a/library/thread/sizedqueue/num_waiting_spec.rb
+++ b/library/thread/sizedqueue/num_waiting_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/num_waiting', __FILE__)
+
+describe "Thread::SizedQueue#num_waiting" do
+  it_behaves_like :queue_num_waiting, :num_waiting, SizedQueue.new(10)
+end

--- a/library/thread/sizedqueue/pop_spec.rb
+++ b/library/thread/sizedqueue/pop_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/deque', __FILE__)
+
+describe "Thread::SizedQueue#pop" do
+  it_behaves_like :queue_deq, :pop, SizedQueue.new(10)
+end

--- a/library/thread/sizedqueue/push_spec.rb
+++ b/library/thread/sizedqueue/push_spec.rb
@@ -1,0 +1,12 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/enque', __FILE__)
+require File.expand_path('../shared/enque', __FILE__)
+
+describe "Thread::SizedQueue#push" do
+  it_behaves_like :queue_enq, :push, SizedQueue.new(10)
+end
+
+describe "Thread::SizedQueue#push" do
+  it_behaves_like :sizedqueue_enq, :push, SizedQueue
+end

--- a/library/thread/sizedqueue/shared/enque.rb
+++ b/library/thread/sizedqueue/shared/enque.rb
@@ -1,0 +1,38 @@
+describe :sizedqueue_enq, :shared => true do
+  it "blocks if queued elements exceed size" do
+    q = @object.new(1)
+
+    q.size.should == 0
+    q.send(@method, :first_element)
+    q.size.should == 1
+
+    blocked_thread = Thread.new { q.send(@method, :second_element) }
+    sleep 0.01 until blocked_thread.stop?
+
+    q.size.should == 1
+    q.pop.should == :first_element
+    q.size.should == 0
+
+    blocked_thread.join
+    q.size.should == 1
+    q.pop.should == :second_element
+    q.size.should == 0
+  end
+
+  ruby_version_is "2.2" do
+    it "raises a ThreadError if queued elements exceed size when not blocking" do
+      q = @object.new(2)
+      method = @method
+
+      non_blocking = true
+      add_to_queue = lambda { q.send(method, Object.new, non_blocking) }
+
+      q.size.should == 0
+      add_to_queue.call
+      q.size.should == 1
+      add_to_queue.call
+      q.size.should == 2
+      add_to_queue.should raise_error(ThreadError)
+    end
+  end
+end

--- a/library/thread/sizedqueue/shift_spec.rb
+++ b/library/thread/sizedqueue/shift_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/deque', __FILE__)
+
+describe "Thread::SizedQueue#shift" do
+  it_behaves_like :queue_deq, :shift, SizedQueue.new(10)
+end

--- a/library/thread/sizedqueue/size_spec.rb
+++ b/library/thread/sizedqueue/size_spec.rb
@@ -1,0 +1,7 @@
+require File.expand_path('../../../../spec_helper', __FILE__)
+require 'thread'
+require File.expand_path('../../shared/queue/length', __FILE__)
+
+describe "Thread::SizedQueue#size" do
+  it_behaves_like :queue_length, :size, SizedQueue.new(10)
+end


### PR DESCRIPTION
Added specification for SizedQueue with shared specifications for Queue.
Queue was orginally specified directly in the library/queue directory but
has now been moved to the library/thread/queue directory since it is
namespaced under Thread.  SizedQueue is also namespaced under Thread so
its specifications are under the library/thread directory also.