### PR TITLE
Specifies creation of a `lambda`

### DIFF
--- a/language/lambda_spec.rb
+++ b/language/lambda_spec.rb
@@ -284,7 +284,10 @@ describe "A lambda expression 'lambda { ... }'" do
     end
 
     it "can be created" do
-      meth { 1 }.().should == 1
+      implicit_lambda = meth { 1 }
+
+      implicit_lambda.lambda?.should be_true
+      implicit_lambda.call.should == 1
     end
   end
 

--- a/language/lambda_spec.rb
+++ b/language/lambda_spec.rb
@@ -274,6 +274,20 @@ describe "A lambda expression 'lambda { ... }'" do
     lambda { }.lambda?.should be_true
   end
 
+  it "requires a block" do
+    lambda { lambda }.should raise_error(ArgumentError)
+  end
+
+  context "with an implicit block" do
+    before do
+      def meth; lambda; end
+    end
+
+    it "can be created" do
+      meth { 1 }.().should == 1
+    end
+  end
+
   context "assigns no local variables" do
     evaluate <<-ruby do
         @a = lambda { }


### PR DESCRIPTION
This tripped me up recently, and seems to be unspecified thus far.
Usually you would expect to capture/call a block using something along
these lines:

```
def meth(&block)
  block.call
end

meth { 'a' } # => "a"
```

However, ruby also supports this syntax via `lambda` and the implicit
block:

```
def meth
  block = lambda
  block.call
end

meth { 'a' } # => "a"
```

This spec serves to describe this behaviour at least, regardless of
whether it is considered /correct/.

Also, I've specified the current behaviour (in MRI at least) when
attempting to create a `lambda` without an implicit block in scope and
without an explicit block argument:

```
lambda # => ArgumentError: tried to create a Proc object without a block
```