### PR TITLE
[RegExp] Add specs for Han, Hiragana, Katakana, Hangul character properties

### DIFF
--- a/language/regexp/character_classes_spec.rb
+++ b/language/regexp/character_classes_spec.rb
@@ -608,4 +608,20 @@ describe "Regexp with character classes" do
   it "matches unicode script properties" do
     "a\u06E9b".match(/\p{Arabic}/).to_a.should == ["\u06E9"]
   end
+
+  it "matches unicode Han properties" do
+    "松本行弘 Ruby".match(/\p{Han}+/u).to_a.should == ["松本行弘"]
+  end
+
+  it "matches unicode Hiragana properties" do
+    "Ruby（ルビー）、まつもとゆきひろ".match(/\p{Hiragana}+/u).to_a.should == ["まつもとゆきひろ"]
+  end
+
+  it "matches unicode Katakana properties" do
+    "Ruby（ルビー）、まつもとゆきひろ".match(/\p{Katakana}+/u).to_a.should == ["ルビ"]
+  end
+
+  it "matches unicode Hangul properties" do
+    "루비(Ruby)".match(/\p{Hangul}+/u).to_a.should == ["루비"]
+  end
 end


### PR DESCRIPTION
Adds four [character properties](http://ruby-doc.org/core-2.2.2/Regexp.html#class-Regexp-label-Character+Properties) specs.