### PR TITLE
Reset @method_args

### DIFF
--- a/core/enumerable/shared/find_all.rb
+++ b/core/enumerable/shared/find_all.rb
@@ -27,5 +27,8 @@ describe :enumerable_find_all, :shared => true do
     multi.send(@method) {|e| e == [3, 4, 5] }.should == [[3, 4, 5]]
   end
 
+  before :all do
+    @method_args = nil
+  end
   it_should_behave_like :enumerable_enumeratorized_with_origin_size
 end

--- a/core/struct/each_pair_spec.rb
+++ b/core/struct/each_pair_spec.rb
@@ -21,6 +21,9 @@ describe "Struct#each_pair" do
     car.each_pair.should be_an_instance_of(enumerator_class)
   end
 
+  before :all do
+    @method_args = nil
+  end
   it_behaves_like :struct_accessor, :each_pair
   it_behaves_like :enumeratorized_with_origin_size, :each_pair, StructClasses::Car.new('Ford', 'Ranger')
 end

--- a/core/struct/each_spec.rb
+++ b/core/struct/each_spec.rb
@@ -22,6 +22,9 @@ describe "Struct#each" do
     car.each.should be_an_instance_of(enumerator_class)
   end
 
+  before :all do
+    @method_args = nil
+  end
   it_behaves_like :struct_accessor, :each
   it_behaves_like :enumeratorized_with_origin_size, :each, StructClasses::Car.new('Ford', 'Ranger')
 end

--- a/core/struct/select_spec.rb
+++ b/core/struct/select_spec.rb
@@ -25,6 +25,9 @@ describe "Struct#select" do
     end
   end
 
+  before :all do
+    @method_args = nil
+  end
   it_behaves_like :struct_accessor, :select
   it_behaves_like :enumeratorized_with_origin_size, :select, Struct.new(:foo).new
 end


### PR DESCRIPTION
@eregon this PR is just to explore an issue I'm having in Opal. I ran into a strange problem with the following specs so far:

* `Struct#each_pair when no block is given returned Enumerator size returns the enumerable size`
* `Struct#each when no block is given returned Enumerator size returns the enumerable size`
* `Struct#select when no block is given returned Enumerator size returns the enumerable size`
* `Enumerable#find_all Enumerable with size when no block is given returned Enumerator size returns the enumerable size`
* `Enumerable#find_all Enumerable with no size when no block is given returned Enumerator size returns nil`
* `Enumerable#select Enumerable with size when no block is given returned Enumerator size returns the enumerable size`
* `Enumerable#select Enumerable with no size when no block is given returned Enumerator size returns nil`

The problem is that for some reason, when the spec executes, for example `Struct#each` is called with an argument, which of course results in an ArgumentError because `String#each` does not accept any arguments. Same for all of the above cases (and there may be more). Interestingly, when I run e.g. `Struct#each` by itself, there's no problem. When I run the whole spec suite, there's a problem. This made me think there's a leaky "global" somewhere, which turns out to be `@method_args`. Resetting `@method_args` as shown in this PR resolves the issue.

Now, I cannot figure out if this is an Opal problem or RubySpec problem. Tried running RubySpec on my 2.2 MRI, got a segfault, and did not have more time to try to make it work. Can you please confirm for me this issue is not a problem on MRI for you? At least then I can zero-in on what's possibly wrong in Opal to make `@method_args` leak across specs.