### PR TITLE
Flags `x`, `n`, and `s` cannot be used in JavaScript regular expressions

### DIFF
--- a/core/regexp/hash_spec.rb
+++ b/core/regexp/hash_spec.rb
@@ -6,10 +6,12 @@ describe "Regexp#hash" do
   end
 
   it "is based on the text and options of Regexp" do
-    (/cat/ix.hash == /cat/ixn.hash).should == true
-    (/dog/m.hash  == /dog/m.hash).should == true
-    (/cat/.hash   == /cat/ix.hash).should == false
     (/cat/.hash   == /dog/.hash).should == false
+    (/dog/m.hash  == /dog/m.hash).should == true
+    not_supported_on :opal do
+      (/cat/ix.hash == /cat/ixn.hash).should == true
+      (/cat/.hash   == /cat/ix.hash).should == false
+    end
   end
 
   it "returns the same value for two Regexps differing only in the /n option" do

--- a/core/regexp/inspect_spec.rb
+++ b/core/regexp/inspect_spec.rb
@@ -2,8 +2,10 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Regexp#inspect" do
   it "returns a formatted string that would eval to the same regexp" do
-    /ab+c/ix.inspect.should == "/ab+c/ix"
-    /a(.)+s/n.inspect.should =~ %r|/a(.)+s/n?|  # Default 'n' may not appear
+    not_supported_on :opal do
+      /ab+c/ix.inspect.should == "/ab+c/ix"
+      /a(.)+s/n.inspect.should =~ %r|/a(.)+s/n?|  # Default 'n' may not appear
+    end
     # 1.9 doesn't round-trip the encoding flags, such as 'u'. This is
     # seemingly by design.
     /a(.)+s/m.inspect.should == "/a(.)+s/m"     # But a specified one does

--- a/core/regexp/source_spec.rb
+++ b/core/regexp/source_spec.rb
@@ -3,7 +3,9 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Regexp#source" do
   it "returns the original string of the pattern" do
-    /ab+c/ix.source.should == "ab+c"
+    not_supported_on :opal do
+      /ab+c/ix.source.should == "ab+c"
+    end
     /x(.)xz/.source.should == "x(.)xz"
   end
 

--- a/core/regexp/to_s_spec.rb
+++ b/core/regexp/to_s_spec.rb
@@ -1,34 +1,42 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Regexp#to_s" do
-  it "displays options if included" do
-     /abc/mxi.to_s.should == "(?mix:abc)"
-   end
-
-   it "shows non-included options after a - sign" do
-     /abc/i.to_s.should == "(?i-mx:abc)"
-   end
-
-   it "shows all options as excluded if none are selected" do
-     /abc/.to_s.should == "(?-mix:abc)"
-   end
-
-   it "shows the pattern after the options" do
-     /ab+c/mix.to_s.should == "(?mix:ab+c)"
-     /xyz/.to_s.should == "(?-mix:xyz)"
-   end
-
-   it "displays groups with options" do
-     /(?ix:foo)(?m:bar)/.to_s.should == "(?-mix:(?ix:foo)(?m:bar))"
-     /(?ix:foo)bar/m.to_s.should == "(?m-ix:(?ix:foo)bar)"
-   end
-
-  it "displays single group with same options as main regex as the main regex" do
-    /(?i:nothing outside this group)/.to_s.should == "(?i-mx:nothing outside this group)"
+  not_supported_on :opal do
+    it "displays options if included" do
+      /abc/mxi.to_s.should == "(?mix:abc)"
+    end
   end
 
-  it "deals properly with uncaptured groups" do
-    /whatever(?:0d)/ix.to_s.should == "(?ix-m:whatever(?:0d))"
+  it "shows non-included options after a - sign" do
+    /abc/i.to_s.should == "(?i-mx:abc)"
+  end
+
+  it "shows all options as excluded if none are selected" do
+    /abc/.to_s.should == "(?-mix:abc)"
+  end
+
+  it "shows the pattern after the options" do
+    not_supported_on :opal do
+      /ab+c/mix.to_s.should == "(?mix:ab+c)"
+    end
+    /xyz/.to_s.should == "(?-mix:xyz)"
+  end
+
+  not_supported_on :opal do
+    it "displays groups with options" do
+      /(?ix:foo)(?m:bar)/.to_s.should == "(?-mix:(?ix:foo)(?m:bar))"
+      /(?ix:foo)bar/m.to_s.should == "(?m-ix:(?ix:foo)bar)"
+    end
+
+    it "displays single group with same options as main regex as the main regex" do
+      /(?i:nothing outside this group)/.to_s.should == "(?i-mx:nothing outside this group)"
+    end
+  end
+
+  not_supported_on :opal do
+    it "deals properly with uncaptured groups" do
+      /whatever(?:0d)/ix.to_s.should == "(?ix-m:whatever(?:0d))"
+    end
   end
 
   it "deals properly with the two types of lookahead groups" do
@@ -37,14 +45,18 @@ describe "Regexp#to_s" do
   end
 
   it "returns a string in (?xxx:yyy) notation" do
-    /ab+c/ix.to_s.should == "(?ix-m:ab+c)"
-    /jis/s.to_s.should == "(?-mix:jis)"
-    /(?i:.)/.to_s.should == "(?i-mx:.)"
+    not_supported_on :opal do
+      /ab+c/ix.to_s.should == "(?ix-m:ab+c)"
+      /jis/s.to_s.should == "(?-mix:jis)"
+      /(?i:.)/.to_s.should == "(?i-mx:.)"
+    end
     /(?:.)/.to_s.should == "(?-mix:.)"
   end
 
-  it "handles abusive option groups" do
-    /(?mmmmix-miiiix:)/.to_s.should == '(?-mix:)'
+  not_supported_on :opal do
+    it "handles abusive option groups" do
+      /(?mmmmix-miiiix:)/.to_s.should == '(?-mix:)'
+    end
   end
 
 end

--- a/core/regexp/try_convert_spec.rb
+++ b/core/regexp/try_convert_spec.rb
@@ -1,8 +1,10 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Regexp.try_convert" do
-  it "returns the argument if given a Regexp" do
-    Regexp.try_convert(/foo/s).should == /foo/s
+  not_supported_on :opal do
+    it "returns the argument if given a Regexp" do
+      Regexp.try_convert(/foo/s).should == /foo/s
+    end
   end
 
   it "returns nil if given an argument that can't be converted to a Regexp" do


### PR DESCRIPTION
Flags `x`, `n`, and `s` cannot be used in JavaScript regular expressions, and regular expressions such as /(?ix:foo)/ are invalid in JavaScript