### PR TITLE
Port Array#bsearch_index spec from ruby/ruby@c64d283

### DIFF
--- a/core/array/bsearch_index_spec.rb
+++ b/core/array/bsearch_index_spec.rb
@@ -81,7 +81,7 @@ ruby_version_is "2.3" do
       end
 
       context "magnitude doesn't effect the result" do
-        it "returns the index of any matched elements where element is between 4n <= xn < 8n, where n is 2**100" do
+        it "returns the index of any matched elements where element is between 4n <= xn < 8n" do
           [1, 2].should include(@array.bsearch_index { |x| (1 - x / 4) * (2**100) })
         end
 

--- a/core/array/bsearch_index_spec.rb
+++ b/core/array/bsearch_index_spec.rb
@@ -26,11 +26,11 @@ ruby_version_is "2.3" do
     end
 
     it "returns nil when passed empty block" do
-      [1, 2, 3].bsearch_index({}).should be_nil
+      [1, 2, 3].bsearch_index {}.should be_nil
     end
 
     it "returns nil when passed block with false" do
-      [1, 2, 3].bsearch_index({ false }).should be_nil
+      [1, 2, 3].bsearch_index { false }.should be_nil
     end
 
     context "minimum mode" do

--- a/core/array/bsearch_index_spec.rb
+++ b/core/array/bsearch_index_spec.rb
@@ -16,21 +16,38 @@ ruby_version_is "2.3" do
         @enum.size.should be_nil
       end
 
-      it "returns index of element given condition in block" do
+      it "returns index of element when block condition is satisfied" do
         @enum.each { |x| x >= 33 }.should == 2
       end
     end
 
-    it "raises TypeError when block passed wrong argument" do
+    it "raises a TypeError when block returns a String" do
       lambda { [1, 2, 3].bsearch_index { "not ok" } }.should raise_error(TypeError)
     end
 
-    it "returns nil when passed empty block" do
+    it "returns nil when block is empty" do
       [1, 2, 3].bsearch_index {}.should be_nil
     end
 
-    it "returns nil when passed block with false" do
+    it "returns nil when block returns false" do
       [1, 2, 3].bsearch_index { false }.should be_nil
+    end
+
+    context "with a block that calls break" do
+      it "returns nil if break is called without a value" do
+        ['a', 'b', 'c'].bsearch_index { |v| break }.should be_nil
+      end
+
+      it "returns nil if break is called with a nil value" do
+        ['a', 'b', 'c'].bsearch_index { |v| break nil }.should be_nil
+      end
+
+      it "returns object if break is called with an object" do
+        ['a', 'b', 'c'].bsearch_index { |v| break 1234 }.should == 1234
+        ['a', 'b', 'c'].bsearch_index { |v| break "hi" }.should == "hi"
+        ['a', 'b', 'c'].bsearch_index { |v| break [42] }.should == [42]
+        ['a', 'b', 'c'].bsearch_index { |v| break Hash(nil) }.should == {}
+      end
     end
 
     context "minimum mode" do
@@ -38,19 +55,19 @@ ruby_version_is "2.3" do
         @array = [0, 4, 7, 10, 12]
       end
 
-      it "x >= 4" do
+      it "returns index of first element which element is greater or equal to 4" do
         @array.bsearch_index { |x| x >= 4 }.should == 1
       end
 
-      it "x >= 6" do
+      it "returns index of first element which element is greater or equal to 6" do
         @array.bsearch_index { |x| x >= 6 }.should == 2
       end
 
-      it "x >= -1" do
+      it "returns index of first element which element is greater or equal to -1" do
         @array.bsearch_index { |x| x >= -1 }.should == 0
       end
 
-      it "x >= 100" do
+      it "returns nil when block condition does not satisfy" do
         @array.bsearch_index { |x| x >= 100 }.should be_nil
       end
     end
@@ -60,37 +77,42 @@ ruby_version_is "2.3" do
         @array = [0, 4, 7, 10, 12]
       end
 
-      it "1 - x / 4" do
-        @array.bsearch_index { |x| 1 - x / 4 }.should == [1, 2]
+      it "returns the index of any matched elements where element is between 4 <= x < 8" do
+        [1, 2].should include(@array.bsearch_index { |x| 1 - x / 4 })
       end
 
-      it "4 - x / 2" do
+      it "returns the index of any matched elements where element is between 8 <= x < 10" do
         @array.bsearch_index { |x| 4 - x / 2 }.should be_nil
       end
 
-      it "1" do
+      it "returns nil when block returns a positive number" do
         @array.bsearch_index { |x| 1 }.should be_nil
       end
 
-      it "-1" do
+      it "returns middle element when block returns zero" do
+        @array.bsearch_index { |x| 0 }.should == 2
+      end
+
+      it "returns nil when block returns a negative number" do
         @array.bsearch_index { |x| -1 }.should be_nil
       end
 
-      it "(1 - x / 4) * (2**100)" do
-        @array.bsearch_index { |x| (1 - x / 4) * (2**100) }.should == [1, 2]
+      context "magnitude doesn't effect the result" do
+        it "returns the index of any matched elements where element is between 4n <= xn < 8n, where n is 2**100" do
+          [1, 2].should include(@array.bsearch_index { |x| (1 - x / 4) * (2**100) })
+        end
+
+        it "returns nil when block returns multiples of 1" do
+          @array.bsearch_index { |x| 1 * (2**100) }.should be_nil
+        end
+
+        it "returns nil when block returns multiples of -1" do
+          @array.bsearch_index { |x| (-1) * (2**100) }.should be_nil
+        end
       end
 
-      it "1 * (2**100)" do
-        @array.bsearch_index { |x| 1 * (2**100) }.should be_nil
-      end
-
-      it "(-1) * (2**100)" do
-        @array.bsearch_index { |x| (-1) * (2**100) }.should be_nil
-      end
-
-      it "(2**100).coerce((1 - x / 4) * (2**100)).first" do
-        @array.bsearch_index { |x| (2**100).coerce((1 - x / 4) * (2**100)).first }
-          .should == [1, 2]
+      it "returns the index of any matched elements for which the block yields true" do
+        [1, 2].should include(@array.bsearch_index { |x| (2**100).coerce((1 - x / 4) * (2**100)).first })
       end
     end
   end

--- a/core/array/bsearch_index_spec.rb
+++ b/core/array/bsearch_index_spec.rb
@@ -33,23 +33,6 @@ ruby_version_is "2.3" do
       [1, 2, 3].bsearch_index { false }.should be_nil
     end
 
-    context "with a block that calls break" do
-      it "returns nil if break is called without a value" do
-        ['a', 'b', 'c'].bsearch_index { |v| break }.should be_nil
-      end
-
-      it "returns nil if break is called with a nil value" do
-        ['a', 'b', 'c'].bsearch_index { |v| break nil }.should be_nil
-      end
-
-      it "returns object if break is called with an object" do
-        ['a', 'b', 'c'].bsearch_index { |v| break 1234 }.should == 1234
-        ['a', 'b', 'c'].bsearch_index { |v| break "hi" }.should == "hi"
-        ['a', 'b', 'c'].bsearch_index { |v| break [42] }.should == [42]
-        ['a', 'b', 'c'].bsearch_index { |v| break Hash(nil) }.should == {}
-      end
-    end
-
     context "minimum mode" do
       before :each do
         @array = [0, 4, 7, 10, 12]

--- a/core/array/bsearch_index_spec.rb
+++ b/core/array/bsearch_index_spec.rb
@@ -1,0 +1,97 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../../enumerable/shared/enumeratorized', __FILE__)
+
+ruby_version_is "2.3" do
+  describe "Array#bsearch_index" do
+    context "when not passed a block" do
+      before :each do
+        @enum = [1, 2, 42, 100, 666].bsearch_index
+      end
+
+      it "returns an Enumerator" do
+        @enum.should be_an_instance_of(enumerator_class)
+      end
+
+      it "returns nil for #size" do
+        @enum.size.should be_nil
+      end
+
+      it "returns index of element given condition in block" do
+        @enum.each { |x| x >= 33 }.should == 2
+      end
+    end
+
+    it "raises TypeError when block passed wrong argument" do
+      lambda { [1, 2, 3].bsearch_index { "not ok" } }.should raise_error(TypeError)
+    end
+
+    it "returns nil when passed empty block" do
+      [1, 2, 3].bsearch_index({}).should be_nil
+    end
+
+    it "returns nil when passed block with false" do
+      [1, 2, 3].bsearch_index({ false }).should be_nil
+    end
+
+    context "minimum mode" do
+      before :each do
+        @array = [0, 4, 7, 10, 12]
+      end
+
+      it "x >= 4" do
+        @array.bsearch_index { |x| x >= 4 }.should == 1
+      end
+
+      it "x >= 6" do
+        @array.bsearch_index { |x| x >= 6 }.should == 2
+      end
+
+      it "x >= -1" do
+        @array.bsearch_index { |x| x >= -1 }.should == 0
+      end
+
+      it "x >= 100" do
+        @array.bsearch_index { |x| x >= 100 }.should be_nil
+      end
+    end
+
+    context "find any mode" do
+      before :each do
+        @array = [0, 4, 7, 10, 12]
+      end
+
+      it "1 - x / 4" do
+        @array.bsearch_index { |x| 1 - x / 4 }.should == [1, 2]
+      end
+
+      it "4 - x / 2" do
+        @array.bsearch_index { |x| 4 - x / 2 }.should be_nil
+      end
+
+      it "1" do
+        @array.bsearch_index { |x| 1 }.should be_nil
+      end
+
+      it "-1" do
+        @array.bsearch_index { |x| -1 }.should be_nil
+      end
+
+      it "(1 - x / 4) * (2**100)" do
+        @array.bsearch_index { |x| (1 - x / 4) * (2**100) }.should == [1, 2]
+      end
+
+      it "1 * (2**100)" do
+        @array.bsearch_index { |x| 1 * (2**100) }.should be_nil
+      end
+
+      it "(-1) * (2**100)" do
+        @array.bsearch_index { |x| (-1) * (2**100) }.should be_nil
+      end
+
+      it "(2**100).coerce((1 - x / 4) * (2**100)).first" do
+        @array.bsearch_index { |x| (2**100).coerce((1 - x / 4) * (2**100)).first }
+          .should == [1, 2]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds specs for `Array#bsearch_index`.

These specs are ported from [ruby/ruby @ c64d283 test/ruby/test_array.rb#L2532-L2565](https://github.com/ruby/ruby/blob/c64d283f9aa01388ebfd2d9d30b0f0a306f25d27/test/ruby/test_array.rb#L2532-L2565).

Fixes #76.

--

[bsearch(3)](http://www.freebsd.org/cgi/man.cgi?query=bsearch&sektion=3&apropos=0&manpath=redhat)