### PR TITLE
Collect and map returns nil when use next in block

### DIFF
--- a/core/enumerable/shared/collect.rb
+++ b/core/enumerable/shared/collect.rb
@@ -28,5 +28,11 @@ describe :enumerable_collect, :shared => true do
     enum.each { |i| -i }.should == [-2, -5, -3, -6, -1, -4]
   end
 
+  it "#collect & #map returns nil when use next in block" do
+    enumerable = [1, 2, 3, 4, 5]
+    enumerable.collect { |i| next }.should == [nil, nil, nil, nil, nil]
+    enumerable.map { |i| next }.should == [nil, nil, nil, nil, nil]
+  end
+
   it_should_behave_like :enumerable_enumeratorized_with_origin_size
 end


### PR DESCRIPTION
This pull request adds spec for `#collect` and `#map` when use `next` in block.

Someday I found this is surprising, do I put this spec in the right file?