### PR TITLE
Discarded $SAFE=3 example with Ruby 2.3

### DIFF
--- a/library/erb/new_spec.rb
+++ b/library/erb/new_spec.rb
@@ -109,10 +109,12 @@ END
   end
 
   not_compliant_on :rubinius do
-    it "accepts a safe level as second argument" do
-      input = "<b><%=- 2+2 %>"
-      safe_level = 3
-      lambda { ERB.new(input, safe_level).result }.should_not raise_error
+    ruby_version_is ''...'2.2' do
+      it "accepts a safe level as second argument" do
+        input = "<b><%=- 2+2 %>"
+        safe_level = 3
+        lambda { ERB.new(input, safe_level).result }.should_not raise_error
+      end
     end
   end
 


### PR DESCRIPTION
I removed $SAFE=3 function at https://github.com/ruby/ruby/commit/bbf440c90b036c733729b1a5c996978ac2adaa9d

