### PR TITLE
fixed wrong version of ruby

### DIFF
--- a/library/erb/new_spec.rb
+++ b/library/erb/new_spec.rb
@@ -109,7 +109,7 @@ END
   end
 
   not_compliant_on :rubinius do
-    ruby_version_is ''...'2.2' do
+    ruby_version_is ''...'2.3' do
       it "accepts a safe level as second argument" do
         input = "<b><%=- 2+2 %>"
         safe_level = 3


### PR DESCRIPTION
Sorry, $SAFE=3 is enabled with Ruby 2.2 :bow: 