### PR TITLE
Add two specs for string concatenations by spaces

### DIFF
--- a/language/string_spec.rb
+++ b/language/string_spec.rb
@@ -267,6 +267,27 @@ end
 
 # TODO: rewrite all specs above this
 
+describe "Ruby String Concatenation by spaces" do
+  def str_concat
+    "foo" "bar" "baz"
+  end
+
+  def long_string_literals
+    "Beautiful is better than ugly." \
+    "Explicit is better than implicit." \
+    "Simple is better than complex." \
+    "Complex is better than complicated."
+  end
+
+  it "returns concatenated string (str_concat)" do
+    str_concat.should == "foobarbaz"
+  end
+
+  it "returns concatenated string (long_string_literals)" do
+    long_string_literals.should == "Beautiful is better than ugly.Explicit is better than implicit.Simple is better than complex.Complex is better than complicated."
+  end
+end
+
 with_feature :encoding do
   describe "Ruby String interpolation" do
     it "creates a String having an Encoding compatible with all components" do

--- a/language/string_spec.rb
+++ b/language/string_spec.rb
@@ -267,7 +267,7 @@ end
 
 # TODO: rewrite all specs above this
 
-describe "Ruby String Concatenation by spaces" do
+describe "Ruby String literals" do
   def str_concat
     "foo" "bar" "baz"
   end
@@ -275,16 +275,14 @@ describe "Ruby String Concatenation by spaces" do
   def long_string_literals
     "Beautiful is better than ugly." \
     "Explicit is better than implicit." \
-    "Simple is better than complex." \
-    "Complex is better than complicated."
   end
 
-  it "returns concatenated string (str_concat)" do
+  it "on a single line with spaces in between are concatenated together" do
     str_concat.should == "foobarbaz"
   end
 
-  it "returns concatenated string (long_string_literals)" do
-    long_string_literals.should == "Beautiful is better than ugly.Explicit is better than implicit.Simple is better than complex.Complex is better than complicated."
+  it "on multiple lines with newlines and backslash in between are concatenated together" do
+    long_string_literals.should == "Beautiful is better than ugly.Explicit is better than implicit."
   end
 end
 


### PR DESCRIPTION
This pull request adds specs for string concatenation by spaces and backslash.

There is `core/string/shared/concat.rb` but this is not defined by particular method, so I think should goes to lanaguage?