### PR TITLE
Separate Time#<=> specs for millisecond vs microsecond precision

### DIFF
--- a/core/time/comparison_spec.rb
+++ b/core/time/comparison_spec.rb
@@ -3,6 +3,14 @@ require File.expand_path('../../../spec_helper', __FILE__)
 describe "Time#<=>" do
   it "returns 1 if the first argument is a point in time after the second argument" do
     (Time.now <=> Time.at(0)).should == 1
+  end
+
+  it "returns 1 if the first argument is a point in time after the second argument (down to a millisecond)" do
+    (Time.at(0, 1000) <=> Time.at(0, 0)).should == 1
+    (Time.at(1202778512, 1000) <=> Time.at(1202778512, 999)).should == 1
+  end
+
+  it "returns 1 if the first argument is a point in time after the second argument (down to a microsecond)" do
     (Time.at(0, 100) <=> Time.at(0, 0)).should == 1
     (Time.at(1202778512, 100) <=> Time.at(1202778512, 99)).should == 1
   end
@@ -14,8 +22,15 @@ describe "Time#<=>" do
 
   it "returns -1 if the first argument is a point in time before the second argument" do
     (Time.at(0) <=> Time.now).should == -1
-    (Time.at(0, 0) <=> Time.at(0, 100)).should == -1
     (Time.at(100, 100) <=> Time.at(101, 100)).should == -1
+  end
+
+  it "returns -1 if the first argument is a point in time before the second argument (down to a millisecond)" do
+    (Time.at(0, 0) <=> Time.at(0, 1000)).should == -1
+  end
+
+  it "returns -1 if the first argument is a point in time before the second argument (down to a microsecond)" do
+    (Time.at(0, 0) <=> Time.at(0, 100)).should == -1
   end
 
   it "returns 1 if the first argument is a fraction of a microsecond after the second argument" do

--- a/shared/process/abort.rb
+++ b/shared/process/abort.rb
@@ -15,7 +15,7 @@ describe :process_abort, :shared => true do
     lambda { @object.abort "message" }.should raise_error { |e| e.message.should == "message" }
   end
 
-  it "sets the exception status code of of 1" do
+  it "sets the exception status code of 1" do
     lambda { @object.abort }.should raise_error { |e| e.status.should == 1 }
   end
 

--- a/shared/time/strftime_for_time.rb
+++ b/shared/time/strftime_for_time.rb
@@ -28,7 +28,7 @@ describe :strftime_time, :shared => true do
   end
 
   describe "with %L" do
-    it "formats the milliseconds of of the second" do
+    it "formats the milliseconds of the second" do
       @new_time[2009, 1, 1, 0, 0, Rational(100, 1000)].strftime("%L").should == "100"
       @new_time[2009, 1, 1, 0, 0, Rational(10, 1000)].strftime("%L").should == "010"
       @new_time[2009, 1, 1, 0, 0, Rational(1, 1000)].strftime("%L").should == "001"


### PR DESCRIPTION
Microsecond precision for time is not possible in JavaScript, but that should not stop Opal from passing Time#<=> specs at millisecond precision.