### PR TITLE
Fix Fixnum plus and minus Bignum to not assume the result is a Bignum

### DIFF
--- a/core/array/fill_spec.rb
+++ b/core/array/fill_spec.rb
@@ -225,7 +225,7 @@ describe "Array#fill with (filler, index, length)" do
 
   deviates_on :rubinius do
     it "raises an ArgumentError if the length is not a Fixnum" do
-      lambda { [1, 2].fill(10, 1, bignum_value()) }.should raise_error(ArgumentError)
+      lambda { [1, 2].fill(10, 1, bignum_value) }.should raise_error(ArgumentError)
     end
   end
 end

--- a/core/bignum/left_shift_spec.rb
+++ b/core/bignum/left_shift_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Bignum#<< with n << m" do
   before :each do
-    @bignum = bignum_value() * 16
+    @bignum = bignum_value * 16
   end
 
   it "returns n shifted left m bits when n > 0, m > 0" do
@@ -35,26 +35,26 @@ describe "Bignum#<< with n << m" do
 
   not_compliant_on :rubinius, :jruby do
     it "returns 0 when m < 0 and m is a Bignum" do
-      (@bignum << -bignum_value()).should == 0
+      (@bignum << -bignum_value).should == 0
     end
   end
 
   deviates_on :rubinius do
     it "raises a RangeError when m < 0 and m is a Bignum" do
-      lambda { @bignum << -bignum_value() }.should raise_error(RangeError)
+      lambda { @bignum << -bignum_value }.should raise_error(RangeError)
     end
   end
 
-  it "returns a Fixnum == fixnum_max() when (fixnum_max() * 2) << -1 and n > 0" do
-    result = (fixnum_max() * 2) << -1
+  it "returns a Fixnum == fixnum_max when (fixnum_max * 2) << -1 and n > 0" do
+    result = (fixnum_max * 2) << -1
     result.should be_an_instance_of(Fixnum)
-    result.should == fixnum_max()
+    result.should == fixnum_max
   end
 
-  it "returns a Fixnum == fixnum_min() when (fixnum_min() * 2) << -1 and n < 0" do
-    result = (fixnum_min() * 2) << -1
+  it "returns a Fixnum == fixnum_min when (fixnum_min * 2) << -1 and n < 0" do
+    result = (fixnum_min * 2) << -1
     result.should be_an_instance_of(Fixnum)
-    result.should == fixnum_min()
+    result.should == fixnum_min
   end
 
   it "calls #to_int to convert the argument to an Integer" do

--- a/core/bignum/right_shift_spec.rb
+++ b/core/bignum/right_shift_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Bignum#>> with n >> m" do
   before :each do
-    @bignum = bignum_value() * 16
+    @bignum = bignum_value * 16
   end
 
   it "returns n shifted right m bits when n > 0, m > 0" do
@@ -61,26 +61,26 @@ describe "Bignum#>> with n >> m" do
 
   not_compliant_on :rubinius do
     it "returns 0 when m is a Bignum" do
-      (@bignum >> bignum_value()).should == 0
+      (@bignum >> bignum_value).should == 0
     end
   end
 
   deviates_on :rubinius do
     it "raises a RangeError when m is a Bignum" do
-      lambda { @bignum >> bignum_value() }.should raise_error(RangeError)
+      lambda { @bignum >> bignum_value }.should raise_error(RangeError)
     end
   end
 
-  it "returns a Fixnum == fixnum_max() when (fixnum_max() * 2) >> 1 and n > 0" do
-    result = (fixnum_max() * 2) >> 1
+  it "returns a Fixnum == fixnum_max when (fixnum_max * 2) >> 1 and n > 0" do
+    result = (fixnum_max * 2) >> 1
     result.should be_an_instance_of(Fixnum)
-    result.should == fixnum_max()
+    result.should == fixnum_max
   end
 
-  it "returns a Fixnum == fixnum_min() when (fixnum_min() * 2) >> 1 and n < 0" do
-    result = (fixnum_min() * 2) >> 1
+  it "returns a Fixnum == fixnum_min when (fixnum_min * 2) >> 1 and n < 0" do
+    result = (fixnum_min * 2) >> 1
     result.should be_an_instance_of(Fixnum)
-    result.should == fixnum_min()
+    result.should == fixnum_min
   end
 
   it "calls #to_int to convert the argument to an Integer" do

--- a/core/fixnum/element_reference_spec.rb
+++ b/core/fixnum/element_reference_spec.rb
@@ -51,12 +51,12 @@ describe "Fixnum#[]" do
 
   it "calls #to_int to coerce a String to a Bignum and returns 0" do
     obj = mock('bignum value')
-    obj.should_receive(:to_int).and_return(bignum_value())
+    obj.should_receive(:to_int).and_return(bignum_value)
 
     3[obj].should == 0
   end
 
   it "returns 0 when passed a Float in the range of a Bignum" do
-    3[bignum_value().to_f].should == 0
+    3[bignum_value.to_f].should == 0
   end
 end

--- a/core/fixnum/left_shift_spec.rb
+++ b/core/fixnum/left_shift_spec.rb
@@ -35,26 +35,26 @@ describe "Fixnum#<< with n << m" do
 
   not_compliant_on :rubinius, :jruby do
     it "returns 0 when m < 0 and m is a Bignum" do
-      (3 << -bignum_value()).should == 0
+      (3 << -bignum_value).should == 0
     end
   end
 
   deviates_on :rubinius do
     it "raises a RangeError when m < 0 and m is a Bignum" do
-      lambda { 3 << -bignum_value() }.should raise_error(RangeError)
+      lambda { 3 << -bignum_value }.should raise_error(RangeError)
     end
   end
 
-  it "returns a Bignum == fixnum_max() * 2 when fixnum_max() << 1 and n > 0" do
-    result = fixnum_max() << 1
+  it "returns a Bignum == fixnum_max * 2 when fixnum_max << 1 and n > 0" do
+    result = fixnum_max << 1
     result.should be_an_instance_of(Bignum)
-    result.should == fixnum_max() * 2
+    result.should == fixnum_max * 2
   end
 
-  it "returns a Bignum == fixnum_min() * 2 when fixnum_min() << 1 and n < 0" do
-    result = fixnum_min() << 1
+  it "returns a Bignum == fixnum_min * 2 when fixnum_min << 1 and n < 0" do
+    result = fixnum_min << 1
     result.should be_an_instance_of(Bignum)
-    result.should == fixnum_min() * 2
+    result.should == fixnum_min * 2
   end
 
   it "calls #to_int to convert the argument to an Integer" do

--- a/core/fixnum/minus_spec.rb
+++ b/core/fixnum/minus_spec.rb
@@ -15,6 +15,7 @@ describe "Fixnum#-" do
 
     bignum_zero = bignum_value.coerce(0).first
     (1 - bignum_zero).should be_an_instance_of Fixnum
+    (fixnum_min() - 1).should be_an_instance_of(Bignum)
   end
 
   it "raises a TypeError when given a non-Integer" do

--- a/core/fixnum/minus_spec.rb
+++ b/core/fixnum/minus_spec.rb
@@ -15,7 +15,7 @@ describe "Fixnum#-" do
 
     bignum_zero = bignum_value.coerce(0).first
     (1 - bignum_zero).should be_an_instance_of Fixnum
-    (fixnum_min() - 1).should be_an_instance_of(Bignum)
+    (fixnum_min - 1).should be_an_instance_of(Bignum)
   end
 
   it "raises a TypeError when given a non-Integer" do

--- a/core/fixnum/plus_spec.rb
+++ b/core/fixnum/plus_spec.rb
@@ -17,12 +17,13 @@ describe "Fixnum#+" do
     lambda { 13 + "10"    }.should raise_error(TypeError)
     lambda { 13 + :symbol }.should raise_error(TypeError)
   end
-  it "overflows to Bignum when the result does not fit in Fixnum" do
-      (5 + 10).should be_an_instance_of Fixnum
-      (1 + bignum_value).should be_an_instance_of Bignum
 
-      bignum_zero = bignum_value.coerce(0).first
-      (1 + bignum_zero).should be_an_instance_of Fixnum
-      (fixnum_max() + 1).should be_an_instance_of(Bignum)
+  it "overflows to Bignum when the result does not fit in Fixnum" do
+    (5 + 10).should be_an_instance_of Fixnum
+    (1 + bignum_value).should be_an_instance_of Bignum
+
+    bignum_zero = bignum_value.coerce(0).first
+    (1 + bignum_zero).should be_an_instance_of Fixnum
+    (fixnum_max() + 1).should be_an_instance_of(Bignum)
   end
 end

--- a/core/fixnum/plus_spec.rb
+++ b/core/fixnum/plus_spec.rb
@@ -24,6 +24,6 @@ describe "Fixnum#+" do
 
     bignum_zero = bignum_value.coerce(0).first
     (1 + bignum_zero).should be_an_instance_of Fixnum
-    (fixnum_max() + 1).should be_an_instance_of(Bignum)
+    (fixnum_max + 1).should be_an_instance_of(Bignum)
   end
 end

--- a/core/fixnum/plus_spec.rb
+++ b/core/fixnum/plus_spec.rb
@@ -17,4 +17,12 @@ describe "Fixnum#+" do
     lambda { 13 + "10"    }.should raise_error(TypeError)
     lambda { 13 + :symbol }.should raise_error(TypeError)
   end
+  it "overflows to Bignum when the result does not fit in Fixnum" do
+      (5 + 10).should be_an_instance_of Fixnum
+      (1 + bignum_value).should be_an_instance_of Bignum
+
+      bignum_zero = bignum_value.coerce(0).first
+      (1 + bignum_zero).should be_an_instance_of Fixnum
+      (fixnum_max() + 1).should be_an_instance_of(Bignum)
+  end
 end

--- a/core/fixnum/right_shift_spec.rb
+++ b/core/fixnum/right_shift_spec.rb
@@ -45,26 +45,26 @@ describe "Fixnum#>> with n >> m" do
 
   not_compliant_on :rubinius do
     it "returns 0 when m is a Bignum" do
-      (3 >> bignum_value()).should == 0
+      (3 >> bignum_value).should == 0
     end
   end
 
   deviates_on :rubinius do
     it "raises a RangeError when m is a Bignum" do
-      lambda { 3 >> bignum_value() }.should raise_error(RangeError)
+      lambda { 3 >> bignum_value }.should raise_error(RangeError)
     end
   end
 
-  it "returns a Bignum == fixnum_max() * 2 when fixnum_max() >> -1 and n > 0" do
-    result = fixnum_max() >> -1
+  it "returns a Bignum == fixnum_max * 2 when fixnum_max >> -1 and n > 0" do
+    result = fixnum_max >> -1
     result.should be_an_instance_of(Bignum)
-    result.should == fixnum_max() * 2
+    result.should == fixnum_max * 2
   end
 
-  it "returns a Bignum == fixnum_min() * 2 when fixnum_min() >> -1 and n < 0" do
-    result = fixnum_min() >> -1
+  it "returns a Bignum == fixnum_min * 2 when fixnum_min >> -1 and n < 0" do
+    result = fixnum_min >> -1
     result.should be_an_instance_of(Bignum)
-    result.should == fixnum_min() * 2
+    result.should == fixnum_min * 2
   end
 
   it "calls #to_int to convert the argument to an Integer" do

--- a/core/integer/round_spec.rb
+++ b/core/integer/round_spec.rb
@@ -30,7 +30,7 @@ describe "Integer#round" do
 
   platform_is_not :wordsize => 32 do
     it "raises a RangeError when passed a big negative value" do
-      lambda { 42.round(fixnum_min()) }.should raise_error(RangeError)
+      lambda { 42.round(fixnum_min) }.should raise_error(RangeError)
     end
   end
 


### PR DESCRIPTION
- I'm working on Bignums for Opal, but i found out that rubyspec do not cover the overflow of Fixnum to Bignum when adding two Fixnums. 

- Same for minus.