### PR TITLE
Add missing cases for Array#&, Array#|, and Array#-

### DIFF
--- a/core/array/intersection_spec.rb
+++ b/core/array/intersection_spec.rb
@@ -43,6 +43,7 @@ describe "Array#&" do
     not_supported_on :opal do
       ([5.0, 4.0] & [5, 4]).should == []
     end
+
     str = "x"
     ([str] & [str.dup]).should == [str]
 
@@ -54,11 +55,13 @@ describe "Array#&" do
     def obj2.eql? a; true; end
 
     ([obj1] & [obj2]).should == [obj1]
+    ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj1]
 
     def obj1.eql? a; false; end
     def obj2.eql? a; false; end
 
     ([obj1] & [obj2]).should == []
+    ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj2]
   end
 
   it "does return subclass instances for Array subclasses" do

--- a/core/array/minus_spec.rb
+++ b/core/array/minus_spec.rb
@@ -46,21 +46,23 @@ describe "Array#-" do
   it "removes an item identified as equivalent via #hash and #eql?" do
     obj1 = mock('1')
     obj2 = mock('2')
-    obj1.should_receive(:hash).and_return(0)
-    obj2.should_receive(:hash).and_return(0)
-    obj1.should_receive(:eql?).with(obj2).and_return(true)
+    obj1.should_receive(:hash).at_least(1).and_return(0)
+    obj2.should_receive(:hash).at_least(1).and_return(0)
+    obj1.should_receive(:eql?).at_least(1).and_return(true)
 
     ([obj1] - [obj2]).should == []
+    ([obj1, obj1, obj2, obj2] - [obj2]).should == []
   end
 
   it "doesn't remove an item with the same hash but not #eql?" do
     obj1 = mock('1')
     obj2 = mock('2')
-    obj1.should_receive(:hash).and_return(0)
-    obj2.should_receive(:hash).and_return(0)
-    obj1.should_receive(:eql?).with(obj2).and_return(false)
+    obj1.should_receive(:hash).at_least(1).and_return(0)
+    obj2.should_receive(:hash).at_least(1).and_return(0)
+    obj1.should_receive(:eql?).at_least(1).and_return(false)
 
     ([obj1] - [obj2]).should == [obj1]
+    ([obj1, obj1, obj2, obj2] - [obj2]).should == [obj1, obj1]
   end
 
   it "removes an identical item even when its #eql? isn't reflexive" do

--- a/core/array/union_spec.rb
+++ b/core/array/union_spec.rb
@@ -36,7 +36,10 @@ describe "Array#|" do
 
   # MRI follows hashing semantics here, so doesn't actually call eql?/hash for Fixnum/Symbol
   it "acts as if using an intermediate hash to collect values" do
-    ([5.0, 4.0] | [5, 4]).should == [5.0, 4.0, 5, 4]
+    not_supported_on :opal do
+      ([5.0, 4.0] | [5, 4]).should == [5.0, 4.0, 5, 4]
+    end
+
     str = "x"
     ([str] | [str.dup]).should == [str]
 
@@ -48,11 +51,13 @@ describe "Array#|" do
     def obj2.eql? a; true; end
 
     ([obj1] | [obj2]).should == [obj1]
+    ([obj1, obj1, obj2, obj2] | [obj2]).should == [obj1]
 
     def obj1.eql? a; false; end
     def obj2.eql? a; false; end
 
     ([obj1] | [obj2]).should == [obj1, obj2]
+    ([obj1, obj1, obj2, obj2] | [obj2]).should == [obj1, obj2]
   end
 
   it "does not return subclass instances for Array subclasses" do


### PR DESCRIPTION
Looking at Opal's implementation of `Array#&`, I noticed that it does not compare items in `self` using `eql?`, i.e. it only uses `eql?` to compare items in `self` with items in `other` array, but not within `self`. This is incorrect, and yet this implementation is successfully passing RubySpec at this time. These additional cases make it fail.