### PR TITLE
Can't use should_receive to test Array#{&,-,|} because it uses hash and eql? internally

### DIFF
--- a/core/array/intersection_spec.rb
+++ b/core/array/intersection_spec.rb
@@ -49,18 +49,18 @@ describe "Array#&" do
 
     obj1 = mock('1')
     obj2 = mock('2')
-    obj1.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:hash).at_least(1).and_return(0)
-    obj1.should_receive(:eql?).at_least(1).and_return(true)
+    # Can't use should_receive because it uses hash and eql? internally
+    def obj1.hash; 0; end
+    def obj2.hash; 0; end
+    def obj1.eql? a; true; end
+    def obj2.eql? a; true; end
 
     ([obj1] & [obj2]).should == [obj1]
     ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj1]
 
-    obj1 = mock('3')
-    obj2 = mock('4')
-    obj1.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:hash).at_least(1).and_return(0)
-    obj1.should_receive(:eql?).at_least(1).and_return(false)
+    # Can't use should_receive because it uses hash and eql? internally
+    def obj1.eql? a; false; end
+    def obj2.eql? a; false; end
 
     ([obj1] & [obj2]).should == []
     ([obj1, obj1, obj2, obj2] & [obj2]).should == [obj2]

--- a/core/array/minus_spec.rb
+++ b/core/array/minus_spec.rb
@@ -46,9 +46,12 @@ describe "Array#-" do
   it "removes an item identified as equivalent via #hash and #eql?" do
     obj1 = mock('1')
     obj2 = mock('2')
-    obj1.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:hash).at_least(1).and_return(0)
-    obj1.should_receive(:eql?).at_least(1).and_return(true)
+    # Can't use should_receive because it uses hash and eql? internally
+    def obj1.hash; 0; end
+    def obj2.hash; 0; end
+    def obj1.eql? a; true; end
+    def obj2.eql? a; true; end
+
 
     ([obj1] - [obj2]).should == []
     ([obj1, obj1, obj2, obj2] - [obj2]).should == []
@@ -57,9 +60,11 @@ describe "Array#-" do
   it "doesn't remove an item with the same hash but not #eql?" do
     obj1 = mock('1')
     obj2 = mock('2')
-    obj1.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:hash).at_least(1).and_return(0)
-    obj1.should_receive(:eql?).at_least(1).and_return(false)
+    # Can't use should_receive because it uses hash and eql? internally
+    def obj1.hash; 0; end
+    def obj2.hash; 0; end
+    def obj1.eql? a; false; end
+    def obj2.eql? a; false; end
 
     ([obj1] - [obj2]).should == [obj1]
     ([obj1, obj1, obj2, obj2] - [obj2]).should == [obj1, obj1]

--- a/core/array/union_spec.rb
+++ b/core/array/union_spec.rb
@@ -45,18 +45,18 @@ describe "Array#|" do
 
     obj1 = mock('1')
     obj2 = mock('2')
-    obj1.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:eql?).at_least(1).and_return(true)
+    # Can't use should_receive because it uses hash and eql? internally
+    def obj1.hash; 0; end
+    def obj2.hash; 0; end
+    def obj1.eql? a; true; end
+    def obj2.eql? a; true; end
 
     ([obj1] | [obj2]).should == [obj1]
     ([obj1, obj1, obj2, obj2] | [obj2]).should == [obj1]
 
-    obj1 = mock('3')
-    obj2 = mock('4')
-    obj1.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:hash).at_least(1).and_return(0)
-    obj2.should_receive(:eql?).at_least(1).and_return(false)
+    # Can't use should_receive because it uses hash and eql? internally
+    def obj1.eql? a; false; end
+    def obj2.eql? a; false; end
 
     ([obj1] | [obj2]).should == [obj1, obj2]
     ([obj1, obj1, obj2, obj2] | [obj2]).should == [obj1, obj2]


### PR DESCRIPTION
@eregon, I noticed this comment sprinkled throughout array specs:
(e.g. https://github.com/ruby/rubyspec/blob/master/core/array/uniq_spec.rb#L22)

> *Can't use should_receive because it uses hash and eql? internally*

So, there was a reason for using singleton methods instead of `should_receive` after all! I'm afraid I broke RubySpec with [this change](https://github.com/ruby/rubyspec/pull/95) :stuck_out_tongue_winking_eye:

This PR puts `intersection_spec` and `union_spec` back to the way they were before https://github.com/ruby/rubyspec/pull/95, makes `minus_spec` work the same way, and adds comments for future maintainers explaining the reason `should_receive` cannot be used in these specs.

And, BTW, switching from `should_receive` back to singleton methods makes Opal fail `Array#&` spec while MRI is at 100%, so that's a good sign!