### PR TITLE
Remove trailing whitespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Specify `core` or `library` as the `base`.
 This is very easy, just run the command below in your `rubyspec` directory.  
 `ruby` must be a recent version of MRI.
 
-    $ ruby --disable-gem ../mspec/bin/mkspec 
+    $ ruby --disable-gem ../mspec/bin/mkspec
 
 You might also want to search for:
 

--- a/core/hash/any_spec.rb
+++ b/core/hash/any_spec.rb
@@ -1,8 +1,8 @@
 require File.expand_path('../../../spec_helper', __FILE__)
 
 describe "Hash#any?" do
-  describe 'with no block given' do 
-    it "checks if there are any members of a Hash" do 
+  describe 'with no block given' do
+    it "checks if there are any members of a Hash" do
       empty_hash = new_hash
       empty_hash.any?.should == false
 
@@ -11,18 +11,18 @@ describe "Hash#any?" do
     end
   end
 
-  describe 'with a block given' do 
-    it 'is false if the hash is empty' do 
+  describe 'with a block given' do
+    it 'is false if the hash is empty' do
       empty_hash = new_hash
       empty_hash.any? {|k,v| 1 == 1 }.should == false
     end
 
-    it 'is true if the block returns true for any member of the hash' do 
+    it 'is true if the block returns true for any member of the hash' do
       hash_with_members = new_hash('a' => false, 'b' => false, 'c' => true, 'd' => false)
       hash_with_members.any? {|k,v| v == true}.should == true
     end
 
-    it 'is false if the block returns false for all members of the hash' do 
+    it 'is false if the block returns false for all members of the hash' do
       hash_with_members = new_hash('a' => false, 'b' => false, 'c' => true, 'd' => false)
       hash_with_members.any? {|k,v| v == 42}.should == false
     end


### PR DESCRIPTION
Found with `grep -r '\s$' ./`.