### PR TITLE
Removed double 'ell' for more distinct character

### DIFF
--- a/core/string/gsub_spec.rb
+++ b/core/string/gsub_spec.rb
@@ -279,7 +279,7 @@ describe "String#gsub with pattern and Hash" do
   end
 
   it "ignores non-String keys" do
-    "hello".gsub(/(ll)/, 'll' => 'r', ll: 'z').should == "hero"
+    "tattoo".gsub(/(tt)/, 'tt' => 'b', tt: 'z').should == "taboo"
   end
 
   it "uses a key's value as many times as needed" do

--- a/core/string/sub_spec.rb
+++ b/core/string/sub_spec.rb
@@ -396,7 +396,7 @@ describe "String#sub with pattern and Hash" do
   end
 
   it "ignores non-String keys" do
-    "hello".sub(/(ll)/, 'll' => 'r', ll: 'z').should == "hero"
+    "tattoo".sub(/(tt)/, 'tt' => 'b', tt: 'z').should == "taboo"
   end
 
   it "uses a key's value only a single time" do


### PR DESCRIPTION
Helps to avoid stroop effect in reading tests when the parts are quickly visually deconstructed.