### PR TITLE
Language/class and module keywords

### DIFF
--- a/language/class_spec.rb
+++ b/language/class_spec.rb
@@ -7,6 +7,20 @@ module ClassSpecs
   Number = 12
 end
 
+describe "The class keyword" do
+  it "creates a new class with semicolon" do
+    class C; end
+    C.should be_an_instance_of(Class)
+  end
+
+  ruby_version_is "2.3" do
+    it "does not raise a SyntaxError when opening a class without a semicolon" do
+      lambda { eval "class C end" }.should_not raise_error(SyntaxError)
+      C.should be_an_instance_of(Class)
+    end
+  end
+end
+
 describe "A class definition" do
   it "creates a new class" do
     ClassSpecs::A.should be_kind_of(Class)

--- a/language/class_spec.rb
+++ b/language/class_spec.rb
@@ -9,14 +9,15 @@ end
 
 describe "The class keyword" do
   it "creates a new class with semicolon" do
-    class C; end
-    C.should be_an_instance_of(Class)
+    class ClassSpecsKeywordWithSemicolon; end
+    ClassSpecsKeywordWithSemicolon.should be_an_instance_of(Class)
   end
 
   ruby_version_is "2.3" do
     it "does not raise a SyntaxError when opening a class without a semicolon" do
-      lambda { eval "class C end" }.should_not raise_error(SyntaxError)
-      C.should be_an_instance_of(Class)
+      lambda { eval "class ClassSpecsKeywordWithoutSemicolon end" }
+        .should_not raise_error(SyntaxError)
+      ClassSpecsKeywordWithoutSemicolon.should be_an_instance_of(Class)
     end
   end
 end

--- a/language/module_spec.rb
+++ b/language/module_spec.rb
@@ -2,6 +2,11 @@ require File.expand_path('../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/module', __FILE__)
 
 describe "The module keyword" do
+  it "creates a new module without semicolon" do
+    module M end
+    M.should be_an_instance_of(Module)
+  end
+
   it "creates a new module with a non-qualified constant name" do
     module ModuleSpecsToplevel; end
     ModuleSpecsToplevel.should be_an_instance_of(Module)

--- a/language/module_spec.rb
+++ b/language/module_spec.rb
@@ -3,8 +3,8 @@ require File.expand_path('../fixtures/module', __FILE__)
 
 describe "The module keyword" do
   it "creates a new module without semicolon" do
-    module M end
-    M.should be_an_instance_of(Module)
+    module ModuleSpecsKeywordWithoutSemicolon end
+    ModuleSpecsKeywordWithoutSemicolon.should be_an_instance_of(Module)
   end
 
   it "creates a new module with a non-qualified constant name" do


### PR DESCRIPTION
Add specs for `module M end`, `class C; end`, and `class C end` (Ruby 2.3)

Inspired from: https://twitter.com/a_matsuda/status/630467339272597504
`class C end`, please see this [commit](https://github.com/ruby/ruby/commit/d311b7d0eb1e973c8d143f03e66ab72588f57a2a).
