### PR TITLE
Specify `superclass` in respect to `prepend`

### DIFF
--- a/core/module/prepend_spec.rb
+++ b/core/module/prepend_spec.rb
@@ -8,6 +8,10 @@ describe "Module#prepend" do
     end
   end
 
+  it "does not affect the superclass" do
+    Class.new { prepend Module.new }.superclass.should == Object
+  end
+
   it "calls #prepend_features(self) in reversed order on each module" do
     ScratchPad.record []
 


### PR DESCRIPTION
This is mainly for jruby/jruby#3276, but also seemed somewhat
unspecified for CRuby - or at least based on my searching through
rubyspec.