### PR TITLE
String#start_with? and #end_with? for empty string

### DIFF
--- a/core/string/end_with_spec.rb
+++ b/core/string/end_with_spec.rb
@@ -14,9 +14,9 @@ describe "String#end_with?" do
     s.end_with?('ll').should be_false
   end
 
-  it "returns true if other is empty" do
-    s = 'hello'
-    s.end_with?('').should be_true
+  it "returns true if the search string is empty" do
+    "hello".end_with?("").should be_true
+    "".end_with?("").should be_true
   end
 
   it "returns true only if any ending match" do

--- a/core/string/start_with_spec.rb
+++ b/core/string/start_with_spec.rb
@@ -16,6 +16,7 @@ describe "String#start_with?" do
 
   it "returns true if the search string is empty" do
     "hello".start_with?("").should be_true
+    "".start_with?("").should be_true
   end
 
   it "converts its argument using :to_str" do


### PR DESCRIPTION
Expanded specs to also cover testing if the empty string starts or ends with the empty string.
And aligned the two specs to look more alike.

JRuby used to differ from other implementations on this.
See https://github.com/jruby/jruby/issues/2434