### PR TITLE
Remove needless "platform_is :solaris" guards.

### DIFF
--- a/core/math/atan2_spec.rb
+++ b/core/math/atan2_spec.rb
@@ -33,40 +33,16 @@ describe "Math.atan2" do
     Math.atan2(0.0, 0.0).should be_positive_zero
   end
 
-  platform_is_not :solaris do
-    it "returns negative zero when passed -0.0, 0.0" do
-      Math.atan2(-0.0, 0.0).should be_negative_zero
-    end
+  it "returns negative zero when passed -0.0, 0.0" do
+    Math.atan2(-0.0, 0.0).should be_negative_zero
   end
 
-  platform_is :solaris do
-    it "returns positive zero when passed -0.0, 0.0" do
-      Math.atan2(-0.0, 0.0).should be_positive_zero
-    end
+  it "returns Pi when passed 0.0, -0.0" do
+    Math.atan2(0.0, -0.0).should == Math::PI
   end
 
-  platform_is_not :solaris do
-    it "returns Pi when passed 0.0, -0.0" do
-      Math.atan2(0.0, -0.0).should == Math::PI
-    end
-  end
-
-  platform_is :solaris do
-    it "returns positive zero when passed 0.0, -0.0" do
-      Math.atan2(0.0, -0.0).should be_positive_zero
-    end
-  end
-
-  platform_is_not :solaris do
-    it "returns -Pi when passed -0.0, -0.0" do
-      Math.atan2(-0.0, -0.0).should == -Math::PI
-    end
-  end
-
-  platform_is :solaris do
-    it "returns positive zero when passed -0.0, -0.0" do
-      Math.atan2(-0.0, -0.0).should be_positive_zero
-    end
+  it "returns -Pi when passed -0.0, -0.0" do
+    Math.atan2(-0.0, -0.0).should == -Math::PI
   end
 
 end


### PR DESCRIPTION
 * See https://github.com/ruby/rubyspec/issues/127
 * This partly reverts ac7ca51b22fa8e5891a69d8b67f71a8616cfea4c