### PR TITLE
Stop generating dynamic test names for lambda.

### DIFF
--- a/core/kernel/shared/lambda.rb
+++ b/core/kernel/shared/lambda.rb
@@ -10,7 +10,7 @@ describe :kernel_lambda, shared: true do
 end
 
 describe :kernel_lambda_return_like_method, shared: true do
-  it "returns from the #{@method} itself, not the creation site of the #{@method}" do
+  it "returns from the lambda itself, not the creation site of the lambda" do
     @reached_end_of_method = nil
     def test
       send(@method) { return }.call


### PR DESCRIPTION
The issue is the following: `@method` variable is not available if `describe` context. It causes mspec to generate random test names depending on some random value of `@method` variable (which makes it  impossible to exclude this specific test from test suite). :smile: 