### PR TITLE
CCDLFLAGS should be used to build Position Independent Code

### DIFF
--- a/optional/capi/spec_helper.rb
+++ b/optional/capi/spec_helper.rb
@@ -65,7 +65,7 @@ def compile_extension(name)
   cc        = RbConfig::CONFIG["CC"]
   cflags    = (ENV["CFLAGS"] || RbConfig::CONFIG["CFLAGS"]).dup
   cflags   += " #{RbConfig::CONFIG["ARCH_FLAG"]}" if RbConfig::CONFIG["ARCH_FLAG"]
-  cflags   += " -fPIC" unless cflags.include?("-fPIC")
+  cflags   += " #{RbConfig::CONFIG["CCDLFLAGS"]}" if RbConfig::CONFIG["CCDLFLAGS"]
   incflags  = "-I#{path} -I#{hdrdir}"
   incflags << " -I#{arch_hdrdir}" if arch_hdrdir
   incflags << " -I#{ruby_hdrdir}" if ruby_hdrdir


### PR DESCRIPTION
* "-fPIC" should not be hardcoded. To build Position Independent Code
  for shared object, RbConfig::CONFIG["CCDLFLAGS"] should be used.
* This change resolves link error "relocations based on the ABS44
  coding model can not be used in building a shared object" occurred
  on Solaris 10 with Fujitsu C Compiler (fcc).