### PR TITLE
Regex === and non-encoding friendly options/match specs

### DIFF
--- a/core/regexp/case_compare_spec.rb
+++ b/core/regexp/case_compare_spec.rb
@@ -16,4 +16,10 @@ describe "Regexp#===" do
   it "returns false if it does not match a Symbol" do
     (/a/ === :b).should be_false
   end
+
+  # mirroring https://github.com/ruby/ruby/blob/trunk/test/ruby/test_regexp.rb
+  it "returns false if the other value cannot be coerced to a string" do
+    (/abc/ === nil).should be_false
+    (/abc/ === /abc/).should be_false
+  end
 end

--- a/core/regexp/match_spec.rb
+++ b/core/regexp/match_spec.rb
@@ -33,6 +33,10 @@ describe "Regexp#match" do
   it "returns a MatchData object, when argument is a Symbol" do
     /(.)(.)(.)/.match(:abc).should be_kind_of(MatchData)
   end
+  
+  it "raises a TypeError on an uninitialized Regexp" do
+    lambda { Regexp.allocate.match('foo') }.should raise_error(TypeError)
+  end
 
   describe "with [string, position]" do
     describe "when given a positive position" do

--- a/core/regexp/options_spec.rb
+++ b/core/regexp/options_spec.rb
@@ -22,6 +22,10 @@ describe "Regexp#options" do
       (/cat/xi.options & Regexp::EXTENDED).should_not == 0
     end
   end
+  
+  it "retrieves options on an empty expression" do
+    //.options.should == 0
+  end
 
   it "raises a TypeError on an uninitialized Regexp" do
     lambda { Regexp.allocate.options }.should raise_error(TypeError)


### PR DESCRIPTION
Opal is treating // as if it was created with Regexp.allocate, so add a non encoding based options test of // that it can execute and also test that match fails the same way options does