### PR TITLE
Object instead of a String for singleton spec

### DIFF
--- a/core/kernel/define_singleton_method_spec.rb
+++ b/core/kernel/define_singleton_method_spec.rb
@@ -60,11 +60,11 @@ describe "Kernel#define_singleton_method" do
   end
 
   it "defines a new singleton method for objects" do
-    s = "hello"
-    s.define_singleton_method(:test) { "world!" }
-    s.test.should == "world!"
+    obj = Object.new
+    obj.define_singleton_method(:test) { "world!" }
+    obj.test.should == "world!"
     lambda {
-      "hello".test
+      Object.new.test
     }.should raise_error(NoMethodError)
   end
 


### PR DESCRIPTION
Other specs should have the responsibility of checking that two equal
strings are different objects.