### PR TITLE
Fully test multiple remove_methods at once

### DIFF
--- a/core/module/remove_method_spec.rb
+++ b/core/module/remove_method_spec.rb
@@ -25,6 +25,13 @@ module ModuleSpecs
   class Second < First
     def method_to_remove; 2; end
   end
+  
+  class Multiple
+    def method_to_remove_1; 1; end
+    def method_to_remove_2; 2; end
+    
+    remove_method :method_to_remove_1, :method_to_remove_2
+  end
 end
 
 describe "Module#remove_method" do
@@ -45,6 +52,12 @@ describe "Module#remove_method" do
     x = ModuleSpecs::Child.new
     x.respond_to?(:method_to_remove).should == true
     x.method_to_remove.should == 1
+  end
+  
+  it "removes multiple methods with 1 call" do
+    x = ModuleSpecs::Multiple.new
+    x.respond_to?(:method_to_remove_1).should == false
+    x.respond_to?(:method_to_remove_2).should == false
   end
 
   it "accepts multiple arguments" do

--- a/core/module/undef_method_spec.rb
+++ b/core/module/undef_method_spec.rb
@@ -6,6 +6,11 @@ module ModuleSpecs
     def method_to_undef() 1 end
     def another_method_to_undef() 1 end
   end
+  
+  class MultipleAtOnce
+    def method_to_undef() 1 end
+    def another_method_to_undef() 1 end
+  end
 
   class Parent
     def method_to_undef() 1 end
@@ -35,6 +40,14 @@ describe "Module#undef_method" do
 
   it "requires multiple arguments" do
     Module.instance_method(:undef_method).arity.should < 0
+  end
+  
+  it "allows multiple methods to be removed at once" do
+    x = ModuleSpecs::MultipleAtOnce.new
+    ModuleSpecs::MultipleAtOnce.send :undef_method, :method_to_undef, :another_method_to_undef
+    
+    lambda { x.method_to_undef }.should raise_error(NoMethodError)
+    lambda { x.another_method_to_undef }.should raise_error(NoMethodError)
   end
 
   it "does not undef any instance methods when argument not given" do


### PR DESCRIPTION
Existing test covers arity, but this ensures it actually works

Also covers what was mentioned in https://github.com/ruby/rubyspec/pull/145