### PR TITLE
Tighten up ancestors specs

### DIFF
--- a/core/module/ancestors_spec.rb
+++ b/core/module/ancestors_spec.rb
@@ -2,14 +2,21 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Module#ancestors" do
-  it "returns a list of modules included in self (including self)" do
-    BasicObject.ancestors.should == [BasicObject]
-    ModuleSpecs.ancestors.should         include(ModuleSpecs)
-    ModuleSpecs::Basic.ancestors.should  include(ModuleSpecs::Basic)
-    ModuleSpecs::Super.ancestors.should  include(ModuleSpecs::Super, ModuleSpecs::Basic)
-    ModuleSpecs::Parent.ancestors.should include(ModuleSpecs::Parent, Object, Kernel)
-    ModuleSpecs::Child.ancestors.should  include(ModuleSpecs::Child, ModuleSpecs::Super, ModuleSpecs::Basic, ModuleSpecs::Parent, Object, Kernel)
+  def without_test_classes(klasses)
+    ignore = %w{MSpec PP::ObjectMixin}
+    klasses.reject {|k| ignore.any? {|i| k.name.start_with?(i) } }
   end
+  
+  it "returns a list of modules included in self (including self)" do
+    BasicObject.ancestors.should         == [BasicObject]
+    ModuleSpecs.ancestors.should         == [ModuleSpecs]
+    ModuleSpecs::Basic.ancestors.should  == [ModuleSpecs::Basic]
+    ModuleSpecs::Super.ancestors.should  == [ModuleSpecs::Super, ModuleSpecs::Basic]
+    without_test_classes(ModuleSpecs::Parent.ancestors)
+    .should                              == [ModuleSpecs::Parent, Object, Kernel, BasicObject]
+    without_test_classes(ModuleSpecs::Child.ancestors)
+    .should                              == [ModuleSpecs::Child, ModuleSpecs::Super, ModuleSpecs::Basic, ModuleSpecs::Parent, Object, Kernel, BasicObject]
+  end  
 
   it "returns only modules and classes" do
     class << ModuleSpecs::Child; self; end.ancestors.should include(ModuleSpecs::Internal, Class, Module, Object, Kernel)

--- a/core/module/ancestors_spec.rb
+++ b/core/module/ancestors_spec.rb
@@ -2,19 +2,14 @@ require File.expand_path('../../../spec_helper', __FILE__)
 require File.expand_path('../fixtures/classes', __FILE__)
 
 describe "Module#ancestors" do
-  def without_test_classes(klasses)
-    ignore = %w{MSpec PP::ObjectMixin}
-    klasses.reject {|k| ignore.any? {|i| k.name.start_with?(i) } }
-  end
-  
   it "returns a list of modules included in self (including self)" do
     BasicObject.ancestors.should         == [BasicObject]
     ModuleSpecs.ancestors.should         == [ModuleSpecs]
     ModuleSpecs::Basic.ancestors.should  == [ModuleSpecs::Basic]
     ModuleSpecs::Super.ancestors.should  == [ModuleSpecs::Super, ModuleSpecs::Basic]
-    without_test_classes(ModuleSpecs::Parent.ancestors)
+    ModuleSpecs.without_test_classes(ModuleSpecs::Parent.ancestors)
     .should                              == [ModuleSpecs::Parent, Object, Kernel, BasicObject]
-    without_test_classes(ModuleSpecs::Child.ancestors)
+    ModuleSpecs.without_test_classes(ModuleSpecs::Child.ancestors)
     .should                              == [ModuleSpecs::Child, ModuleSpecs::Super, ModuleSpecs::Basic, ModuleSpecs::Parent, Object, Kernel, BasicObject]
   end  
 

--- a/core/module/fixtures/classes.rb
+++ b/core/module/fixtures/classes.rb
@@ -1,4 +1,9 @@
 module ModuleSpecs
+  def self.without_test_classes(klasses)
+    ignore = %w{MSpec PP::ObjectMixin ModuleSpecs::IncludedInObject MainSpecs::Module ConstantSpecs::ModuleA}
+    klasses.reject {|k| ignore.any? {|i| k.name.start_with?(i) } }
+  end
+  
   CONST = :plain_constant
 
   module PrivConstModule


### PR DESCRIPTION
All of the includes do not prevent unexpected results from being in the ancestor list. Tried to exclude any test modules that may end up in here