### PR TITLE
Follow up for https://github.com/ruby/rubyspec/pull/153

### DIFF
--- a/core/module/fixtures/classes.rb
+++ b/core/module/fixtures/classes.rb
@@ -1,6 +1,6 @@
 module ModuleSpecs
   def self.without_test_modules(modules)
-    ignore = %w[MSpec PP::ObjectMixin ModuleSpecs::IncludedInObject MainSpecs::Module ConstantSpecs::ModuleA]
+    ignore = %w[MSpecRSpecAdapter PP::ObjectMixin ModuleSpecs::IncludedInObject MainSpecs::Module ConstantSpecs::ModuleA]
     modules.reject { |k| ignore.include?(k.name) }
   end
   


### PR DESCRIPTION
Since start_with was removed, that made the exact test invalid on Opal