### PR TITLE
Set Net::FTP.default_passive to false.

### DIFF
--- a/library/net/ftp/abort_spec.rb
+++ b/library/net/ftp/abort_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#abort" do

--- a/library/net/ftp/acct_spec.rb
+++ b/library/net/ftp/acct_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#acct" do

--- a/library/net/ftp/binary_spec.rb
+++ b/library/net/ftp/binary_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#binary" do
   it "returns true when self is in binary mode" do

--- a/library/net/ftp/chdir_spec.rb
+++ b/library/net/ftp/chdir_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#chdir" do

--- a/library/net/ftp/close_spec.rb
+++ b/library/net/ftp/close_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#close" do
   before :each do

--- a/library/net/ftp/closed_spec.rb
+++ b/library/net/ftp/closed_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#closed?" do
   before :each do

--- a/library/net/ftp/connect_spec.rb
+++ b/library/net/ftp/connect_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 # TODO: Add specs for using the SOCKSSocket

--- a/library/net/ftp/debug_mode_spec.rb
+++ b/library/net/ftp/debug_mode_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#debug_mode" do
   it "returns true when self is in debug mode" do

--- a/library/net/ftp/delete_spec.rb
+++ b/library/net/ftp/delete_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#delete" do

--- a/library/net/ftp/dir_spec.rb
+++ b/library/net/ftp/dir_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/list', __FILE__)
 

--- a/library/net/ftp/get_spec.rb
+++ b/library/net/ftp/get_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/gettextfile', __FILE__)
 require File.expand_path('../shared/getbinaryfile', __FILE__)

--- a/library/net/ftp/getbinaryfile_spec.rb
+++ b/library/net/ftp/getbinaryfile_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/getbinaryfile', __FILE__)
 

--- a/library/net/ftp/getdir_spec.rb
+++ b/library/net/ftp/getdir_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../shared/pwd', __FILE__)
 
 describe "Net::FTP#getdir" do

--- a/library/net/ftp/gettextfile_spec.rb
+++ b/library/net/ftp/gettextfile_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/gettextfile', __FILE__)
 

--- a/library/net/ftp/help_spec.rb
+++ b/library/net/ftp/help_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#help" do

--- a/library/net/ftp/initialize_spec.rb
+++ b/library/net/ftp/initialize_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#initialize" do
   before :each do

--- a/library/net/ftp/last_response_code_spec.rb
+++ b/library/net/ftp/last_response_code_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../shared/last_response_code', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 

--- a/library/net/ftp/last_response_spec.rb
+++ b/library/net/ftp/last_response_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#last_response" do

--- a/library/net/ftp/lastresp_spec.rb
+++ b/library/net/ftp/lastresp_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../shared/last_response_code', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 

--- a/library/net/ftp/list_spec.rb
+++ b/library/net/ftp/list_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/list', __FILE__)
 

--- a/library/net/ftp/login_spec.rb
+++ b/library/net/ftp/login_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#login" do

--- a/library/net/ftp/ls_spec.rb
+++ b/library/net/ftp/ls_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/list', __FILE__)
 

--- a/library/net/ftp/mdtm_spec.rb
+++ b/library/net/ftp/mdtm_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#mdtm" do

--- a/library/net/ftp/mkdir_spec.rb
+++ b/library/net/ftp/mkdir_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#mkdir" do

--- a/library/net/ftp/mtime_spec.rb
+++ b/library/net/ftp/mtime_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#mtime" do

--- a/library/net/ftp/nlst_spec.rb
+++ b/library/net/ftp/nlst_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#nlst" do

--- a/library/net/ftp/noop_spec.rb
+++ b/library/net/ftp/noop_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#noop" do

--- a/library/net/ftp/open_spec.rb
+++ b/library/net/ftp/open_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP.open" do
   before :each do

--- a/library/net/ftp/passive_spec.rb
+++ b/library/net/ftp/passive_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#passive" do
   it "returns true when self is in passive mode" do

--- a/library/net/ftp/put_spec.rb
+++ b/library/net/ftp/put_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/puttextfile', __FILE__)
 require File.expand_path('../shared/putbinaryfile', __FILE__)

--- a/library/net/ftp/putbinaryfile_spec.rb
+++ b/library/net/ftp/putbinaryfile_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/putbinaryfile', __FILE__)
 

--- a/library/net/ftp/puttextfile_spec.rb
+++ b/library/net/ftp/puttextfile_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 require File.expand_path('../shared/puttextfile', __FILE__)
 

--- a/library/net/ftp/pwd_spec.rb
+++ b/library/net/ftp/pwd_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#pwd" do

--- a/library/net/ftp/quit_spec.rb
+++ b/library/net/ftp/quit_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#quit" do

--- a/library/net/ftp/rename_spec.rb
+++ b/library/net/ftp/rename_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#rename" do

--- a/library/net/ftp/resume_spec.rb
+++ b/library/net/ftp/resume_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#resume" do
   it "returns true when self is set to resume uploads/downloads" do

--- a/library/net/ftp/retrbinary_spec.rb
+++ b/library/net/ftp/retrbinary_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#retrbinary" do

--- a/library/net/ftp/retrlines_spec.rb
+++ b/library/net/ftp/retrlines_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#retrlines" do

--- a/library/net/ftp/return_code_spec.rb
+++ b/library/net/ftp/return_code_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#return_code" do
   before :each do

--- a/library/net/ftp/rmdir_spec.rb
+++ b/library/net/ftp/rmdir_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#rmdir" do

--- a/library/net/ftp/sendcmd_spec.rb
+++ b/library/net/ftp/sendcmd_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#sendcmd" do

--- a/library/net/ftp/set_socket_spec.rb
+++ b/library/net/ftp/set_socket_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 
 describe "Net::FTP#set_socket" do
   # TODO: I won't spec this method, as it is not used

--- a/library/net/ftp/site_spec.rb
+++ b/library/net/ftp/site_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#site" do

--- a/library/net/ftp/size_spec.rb
+++ b/library/net/ftp/size_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#size" do

--- a/library/net/ftp/spec_helper.rb
+++ b/library/net/ftp/spec_helper.rb
@@ -1,0 +1,3 @@
+require "net/ftp"
+
+Net::FTP.default_passive = false

--- a/library/net/ftp/spec_helper.rb
+++ b/library/net/ftp/spec_helper.rb
@@ -1,3 +1,5 @@
 require "net/ftp"
 
-Net::FTP.default_passive = false
+if defined?(Net::FTP.default_passive)
+  Net::FTP.default_passive = false
+end

--- a/library/net/ftp/status_spec.rb
+++ b/library/net/ftp/status_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#status" do

--- a/library/net/ftp/storbinary_spec.rb
+++ b/library/net/ftp/storbinary_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#storbinary" do

--- a/library/net/ftp/storlines_spec.rb
+++ b/library/net/ftp/storlines_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#storlines" do

--- a/library/net/ftp/system_spec.rb
+++ b/library/net/ftp/system_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#system" do

--- a/library/net/ftp/voidcmd_spec.rb
+++ b/library/net/ftp/voidcmd_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#voidcmd" do

--- a/library/net/ftp/welcome_spec.rb
+++ b/library/net/ftp/welcome_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('../../../../spec_helper', __FILE__)
-require 'net/ftp'
+require File.expand_path('../spec_helper', __FILE__)
 require File.expand_path('../fixtures/server', __FILE__)
 
 describe "Net::FTP#welcome" do


### PR DESCRIPTION
Set Net::FTP.default_passive to false in spec_helper.rb because connections are in passive mode per default in Ruby 2.3.
