### PR TITLE
[Core/hash] Add specs for Hash #<=, #>=, #<, #> for Ruby 2.3

### DIFF
--- a/core/hash/gt_spec.rb
+++ b/core/hash/gt_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.3" do
+  describe "Hash#>" do
+    before :each do
+      @hash = {a:1, b:2}
+      @bigger = {a:1, b:2, c:3}
+      @unrelated = {c:3, d:4}
+      @similar = {a:2, b:3}
+    end
+
+    it "returns false when receiver size is smaller than argument" do
+      (@hash > @bigger).should == false
+      (@unrelated > @bigger).should == false
+    end
+
+    it "returns false when receiver size is the same as argument" do
+      (@hash > @hash).should == false
+      (@hash > @unrelated).should == false
+      (@unrelated > @hash).should == false
+    end
+
+    it "returns true when argument is a subset of receiver" do
+      (@bigger > @hash).should == true
+    end
+
+    it "returns false when keys match but values don't" do
+      (@hash > @similar).should == false
+      (@similar > @hash).should == false
+    end
+  end
+end

--- a/core/hash/gte_spec.rb
+++ b/core/hash/gte_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.3" do
+  describe "Hash#>=" do
+    before :each do
+      @hash = {a:1, b:2}
+      @bigger = {a:1, b:2, c:3}
+      @unrelated = {c:3, d:4}
+      @similar = {a:2, b:3}
+    end
+
+    it "returns false when receiver size is smaller than argument" do
+      (@hash >= @bigger).should == false
+      (@unrelated >= @bigger).should == false
+    end
+
+    it "returns false when argument is not a subset or not equals to receiver" do
+      (@hash >= @unrelated).should == false
+      (@unrelated >= @hash).should == false
+    end
+
+    it "returns true when argument is a subset of receiver or equals to receiver" do
+      (@bigger >= @hash).should == true
+      (@hash >= @hash).should == true
+    end
+
+    it "returns false when keys match but values don't" do
+      (@hash >= @similar).should == false
+      (@similar >= @hash).should == false
+    end
+  end
+end

--- a/core/hash/lt_spec.rb
+++ b/core/hash/lt_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.3" do
+  describe "Hash#<" do
+    before :each do
+      @hash = {a:1, b:2}
+      @bigger = {a:1, b:2, c:3}
+      @unrelated = {c:3, d:4}
+      @similar = {a:2, b:3}
+    end
+
+    it "returns false when receiver size is larger than argument" do
+      (@bigger < @hash).should == false
+      (@bigger < @unrelated).should == false
+    end
+
+    it "returns false when receiver size is the same as argument" do
+      (@hash < @hash).should == false
+      (@hash < @unrelated).should == false
+      (@unrelated < @hash).should == false
+    end
+
+    it "returns true when receiver is a subset of argument" do
+      (@hash < @bigger).should == true
+    end
+
+    it "returns false when keys match but values don't" do
+      (@hash < @similar).should == false
+      (@similar < @hash).should == false
+    end
+  end
+end

--- a/core/hash/lte_spec.rb
+++ b/core/hash/lte_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+ruby_version_is "2.3" do
+  describe "Hash#<=" do
+    before :each do
+      @hash = {a:1, b:2}
+      @bigger = {a:1, b:2, c:3}
+      @unrelated = {c:3, d:4}
+      @similar = {a:2, b:3}
+    end
+
+    it "returns false when receiver size is larger than argument" do
+      (@bigger <= @hash).should == false
+      (@bigger <= @unrelated).should == false
+    end
+
+    it "returns false when receiver size is the same as argument" do
+      (@hash <= @unrelated).should == false
+      (@unrelated <= @hash).should == false
+    end
+
+    it "returns true when receiver is a subset of argument or equals to argument" do
+      (@hash <= @bigger).should == true
+      (@hash <= @hash).should == true
+    end
+
+    it "returns false when keys match but values don't" do
+      (@hash <= @similar).should == false
+      (@similar <= @hash).should == false
+    end
+  end
+end


### PR DESCRIPTION
specs are from https://github.com/ruby/ruby/blob/d68c3ecf/test/ruby/test_hash.rb#L1311-L1334.