### PR TITLE
Fix infection from Range

### DIFF
--- a/core/range/inspect_spec.rb
+++ b/core/range/inspect_spec.rb
@@ -15,18 +15,16 @@ describe "Range#inspect" do
   it "returns a tainted string if either end is tainted" do
     (("a".taint)..."c").inspect.tainted?.should be_true
     ("a"...("c".taint)).inspect.tainted?.should be_true
-  end
-
-  it "ignores own tainted status" do
-    ("a"..."c").taint.inspect.tainted?.should be_false
+    ruby_bug("#11767", "2.3") do
+      ("a"..."c").taint.inspect.tainted?.should be_true
+    end
   end
 
   it "returns a untrusted string if either end is untrusted" do
     (("a".untrust)..."c").inspect.untrusted?.should be_true
     ("a"...("c".untrust)).inspect.untrusted?.should be_true
-  end
-
-  it "ignores own untrusted status" do
-    ("a"..."c").untrust.inspect.untrusted?.should be_false
+    ruby_bug("#11767", "2.3") do
+      ("a"..."c").untrust.inspect.untrusted?.should be_true
+    end
   end
 end

--- a/core/range/to_s_spec.rb
+++ b/core/range/to_s_spec.rb
@@ -14,18 +14,16 @@ describe "Range#to_s" do
   it "returns a tainted string if either end is tainted" do
     (("a".taint)..."c").to_s.tainted?.should be_true
     ("a"...("c".taint)).to_s.tainted?.should be_true
-  end
-
-  it "ignores own tainted status" do
-    ("a"..."c").taint.to_s.tainted?.should be_false
+    ruby_bug("#11767", "2.3") do
+      ("a"..."c").taint.to_s.tainted?.should be_true
+    end
   end
 
   it "returns a untrusted string if either end is untrusted" do
     (("a".untrust)..."c").to_s.untrusted?.should be_true
     ("a"...("c".untrust)).to_s.untrusted?.should be_true
-  end
-
-  it "ignores own untrusted status" do
-    ("a"..."c").untrust.to_s.untrusted?.should be_false
+    ruby_bug("#11767", "2.3") do
+      ("a"..."c").untrust.to_s.untrusted?.should be_true
+    end
   end
 end


### PR DESCRIPTION
In general, `to_s` and `inspect` on a tainted object should result
a tainted string.  `Range#to_s` and `Range#inspect` have bugs.
https://bugs.ruby-lang.org/issues/11767