### PR TITLE
[ruby-2.3 core/enumerable] - Add specs for Enumerable#chunk_while

### DIFF
--- a/core/enumerable/chunk_while_spec.rb
+++ b/core/enumerable/chunk_while_spec.rb
@@ -1,0 +1,38 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+require File.expand_path('../fixtures/classes', __FILE__)
+
+ruby_version_is "2.3" do
+  describe "Enumerable#chunk_while" do
+    before :each do
+      ary = [10, 9, 7, 6, 4, 3, 2, 1]
+      @enum = EnumerableSpecs::Numerous.new *ary
+      @result = @enum.chunk_while { |i, j| i - 1 == j }
+      @enum_length = ary.length
+    end
+
+    context "when given a block" do
+      it "returns an enumerator" do
+        @result.should be_an_instance_of(enumerator_class)
+      end
+
+      it "splits chunks between adjacent elements i and j where the block returns false" do
+        @result.to_a.should == [[10, 9], [7, 6], [4, 3, 2, 1]]
+      end
+
+      it "calls the block for length of the receiver enumerable minus one times" do
+        times_called = 0
+        @enum.chunk_while do |i, j|
+          times_called += 1
+          i - 1 == j
+        end.to_a
+        times_called.should == (@enum_length - 1)
+      end
+    end
+
+    context "when not given a block" do
+      it "raises an ArgumentError" do
+        lambda { @enum.chunk_while }.should raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding tests for Enumerable#chunk_while.
See: https://github.com/ruby/ruby/blob/trunk/enum.c#L3409
Pretty much just the slice_when test, but with the block return value negated, since that's what chunk_while is.