### PR TITLE
wait for the parent to read

### DIFF
--- a/shared/process/spawn.rb
+++ b/shared/process/spawn.rb
@@ -429,7 +429,7 @@ describe :process_spawn, shared: true do
     it "closes file descriptors >= 3 in the child process" do
       IO.pipe do |r, w|
         begin
-          pid = @object.spawn(ruby_cmd(""), @options)
+          pid = @object.spawn(ruby_cmd("sleep"), @options)
           w.close
           lambda { r.read_nonblock(1) }.should raise_error(EOFError)
         ensure
@@ -472,7 +472,7 @@ describe :process_spawn, shared: true do
     it "closes file descriptors >= 3 in the child process because they are set close_on_exec by default" do
       IO.pipe do |r, w|
         begin
-          pid = @object.spawn(ruby_cmd(""), @options)
+          pid = @object.spawn(ruby_cmd("sleep"), @options)
           w.close
           lambda { r.read_nonblock(1) }.should raise_error(EOFError)
         ensure
@@ -487,7 +487,7 @@ describe :process_spawn, shared: true do
         r.close_on_exec = false
         w.close_on_exec = false
         begin
-          pid = @object.spawn(ruby_cmd(""), @options)
+          pid = @object.spawn(ruby_cmd("sleep"), @options)
           w.close
           lambda { r.read_nonblock(1) }.should raise_error(Errno::EAGAIN)
         ensure


### PR DESCRIPTION
Spawned processes have to wait for the parent process to finish
reading from the reader-side of pipe.  If a child process exits
before the reading, `EOFError` may raise not `Errno::EAGAIN`.
http://rubyci.s3.amazonaws.com/rhel_zlinux/ruby-trunk/log/20151216T003301Z.fail.html.gz